### PR TITLE
Fixed drop_dimension implementation

### DIFF
--- a/openeo_processes_dask/exceptions.py
+++ b/openeo_processes_dask/exceptions.py
@@ -2,6 +2,10 @@ class DimensionNotAvailable(Exception):
     pass
 
 
+class DimensionLabelCountMismatch(Exception):
+    pass
+
+
 class ArrayElementParameterConflict(Exception):
     pass
 

--- a/openeo_processes_dask/exceptions.py
+++ b/openeo_processes_dask/exceptions.py
@@ -1,9 +1,19 @@
 class DimensionNotAvailable(Exception):
-    pass
+    def __init__(self, msg):
+        self.message = "A dimension with the specified name does not exist."
+
+    def __str__(self):
+        return self.message
 
 
 class DimensionLabelCountMismatch(Exception):
-    pass
+    def __init__(self, msg):
+        self.message = (
+            "The number of dimension labels exceeds one, which requires a reducer."
+        )
+
+    def __str__(self):
+        return self.message
 
 
 class ArrayElementParameterConflict(Exception):

--- a/openeo_processes_dask/process_implementations/cubes/general.py
+++ b/openeo_processes_dask/process_implementations/cubes/general.py
@@ -1,7 +1,10 @@
 import xarray as xr
 from openeo_pg_parser_networkx.pg_schema import *
 
-from openeo_processes_dask.exceptions import DimensionNotAvailable, DimensionLabelCountMismatch
+from openeo_processes_dask.exceptions import (
+    DimensionLabelCountMismatch,
+    DimensionNotAvailable,
+)
 from openeo_processes_dask.process_implementations.data_model import RasterCube
 
 __all__ = ["create_raster_cube", "drop_dimension", "dimension_labels"]
@@ -9,13 +12,9 @@ __all__ = ["create_raster_cube", "drop_dimension", "dimension_labels"]
 
 def drop_dimension(data: RasterCube, name: str) -> RasterCube:
     if name not in data.dims:
-        raise DimensionNotAvailable(
-            "A dimension with the specified name does not exist."
-        )
-    if len(data[name])>1:
-        raise DimensionLabelCountMismatch(
-            "The number of dimension labels exceeds one, which requires a reducer."
-        )
+        raise DimensionNotAvailable()
+    if len(data[name]) > 1:
+        raise DimensionLabelCountMismatch()
     return data.drop(name)
 
 
@@ -25,7 +24,5 @@ def create_raster_cube() -> RasterCube:
 
 def dimension_labels(data: RasterCube, dimension: str) -> RasterCube:
     if dimension not in data.dims:
-        raise DimensionNotAvailable(
-            "A dimension with the specified name does not exist."
-        )
+        raise DimensionNotAvailable()
     return data.coords[dimension]

--- a/openeo_processes_dask/process_implementations/cubes/general.py
+++ b/openeo_processes_dask/process_implementations/cubes/general.py
@@ -7,13 +7,13 @@ from openeo_processes_dask.process_implementations.data_model import RasterCube
 __all__ = ["create_raster_cube", "drop_dimension", "dimension_labels"]
 
 
-def drop_dimension(data: RasterCube, dimension: str) -> RasterCube:
-    if dimension not in data.dims:
+def drop_dimension(data: RasterCube, name: str) -> RasterCube:
+    if name not in data.dims:
         raise DimensionNotAvailable(
             "A dimension with the specified name does not exist."
         )
 
-    return data.drop_dims(dimension)
+    return data.drop(dimension)
 
 
 def create_raster_cube() -> RasterCube:

--- a/openeo_processes_dask/process_implementations/cubes/general.py
+++ b/openeo_processes_dask/process_implementations/cubes/general.py
@@ -1,7 +1,7 @@
 import xarray as xr
 from openeo_pg_parser_networkx.pg_schema import *
 
-from openeo_processes_dask.exceptions import DimensionNotAvailable
+from openeo_processes_dask.exceptions import DimensionNotAvailable, DimensionLabelCountMismatch
 from openeo_processes_dask.process_implementations.data_model import RasterCube
 
 __all__ = ["create_raster_cube", "drop_dimension", "dimension_labels"]
@@ -12,8 +12,11 @@ def drop_dimension(data: RasterCube, name: str) -> RasterCube:
         raise DimensionNotAvailable(
             "A dimension with the specified name does not exist."
         )
-
-    return data.drop(dimension)
+    if len(data[name])>1:
+        raise DimensionLabelCountMismatch(
+            "The number of dimension labels exceeds one, which requires a reducer."
+        )
+    return data.drop(name)
 
 
 def create_raster_cube() -> RasterCube:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.11"
+python = ">=3.9,<3.10"
 geopandas = ">=0.11.1,<1"
 xarray = ">=2022.11.0"
 dask = {extras = ["array"], version = ">=2022.11.1"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.10"
+python = ">=3.9,<3.11"
 geopandas = ">=0.11.1,<1"
 xarray = ">=2022.11.0"
 dask = {extras = ["array"], version = ">=2022.11.1"}


### PR DESCRIPTION
Parameter `dimension` renamed to `name`.
Using `.drop` instead of `drop_dims`, which is available only for xArray Datasets https://docs.xarray.dev/en/stable/search.html?q=drop_dims

Solves https://github.com/Open-EO/openeo-processes-dask/issues/13