### PR TITLE
Add .openeo accessor to DataArray

### DIFF
--- a/openeo_processes_dask/__init__.py
+++ b/openeo_processes_dask/__init__.py
@@ -1,1 +1,5 @@
 __version__ = "2022.12.3"
+
+import rioxarray as rio  # Required for the .rio accessor on xarrays.
+
+import openeo_processes_dask.process_implementations.cubes._xr_interop

--- a/openeo_processes_dask/core.py
+++ b/openeo_processes_dask/core.py
@@ -8,7 +8,6 @@ from typing import Callable, Optional
 from openeo_pg_parser_networkx.pg_schema import ParameterReference
 
 from openeo_processes_dask.exceptions import ProcessParameterMissing
-from openeo_processes_dask.process_implementations.cubes.utils import RENAME_DIMS
 
 logger = logging.getLogger(__name__)
 
@@ -42,11 +41,6 @@ def process(f):
                     )
             else:
                 resolved_kwargs[k] = v
-
-        # If necessary, rename dimension names here too!
-        for k, v in resolved_kwargs.items():
-            if k in ["dimension", "dim"] and v in RENAME_DIMS.keys():
-                resolved_kwargs[k] = RENAME_DIMS[v]
 
         pretty_args = {k: type(v) for k, v in resolved_kwargs.items()}
         logger.warning(f"Running process {f.__name__}")

--- a/openeo_processes_dask/process_implementations/cubes/_filter.py
+++ b/openeo_processes_dask/process_implementations/cubes/_filter.py
@@ -15,7 +15,7 @@ def filter_bbox(data: RasterCube, extent: BoundingBox) -> RasterCube:
 
 
 def filter_temporal(
-    data: RasterCube, extent: TemporalInterval, dimension: str = "time"
+    data: RasterCube, extent: TemporalInterval, dimension: str
 ) -> RasterCube:
     raise NotImplementedError()
 

--- a/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
+++ b/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import odc.geo.xr  # Required for the .geo accessor on xarrays.
 import xarray as xr
 
@@ -10,40 +12,46 @@ class OpenEOExtensionDa:
         self._obj = xarray_obj
 
     @property
-    def x_dim(self):
+    def x_dim(self) -> Optional[str]:
         spatial_dims = self._obj.odc.spatial_dims
         if spatial_dims is not None:
             return spatial_dims[1]
-        raise DimensionNotAvailable(
-            f"Unable to identify spatial dimensions on datacube. Available dimensions: {self._obj.dims}"
-        )
+        return None
 
     @property
-    def y_dim(self):
+    def y_dim(self) -> Optional[str]:
         spatial_dims = self._obj.odc.spatial_dims
         if spatial_dims is not None:
             return spatial_dims[0]
-        raise DimensionNotAvailable(
-            f"Unable to identify spatial dimensions on datacube. Available dimensions: {self._obj.dims}"
-        )
+        return None
 
     @property
     def z_dim(self):
-        return NotImplemented()
+        raise NotImplementedError()
 
     @property
-    def time_dim(self):
-        guesses = ["time", "t"]
+    def temporal_dims(self) -> Optional[list]:
+        """Find and return all temporal dimensions of the datacube as a list."""
+        guesses = [
+            "time",
+            "t",
+            "year",
+            "quarter",
+            "month",
+            "week",
+            "day",
+            "hour",
+            "second",
+        ]
 
-        dims = {str(dim) for dim in self._obj.dims}
+        dims = {str(dim).casefold(): str(dim) for dim in self._obj.dims}
 
+        temporal_dims = []
         for guess in guesses:
-            if dims.issuperset(guess):
-                return guess
+            if guess in dims:
+                temporal_dims.append(dims[guess])
 
-        raise DimensionNotAvailable(
-            f"Unable to identify temporal dimension on datacube. Available dimensions: {self._obj.dims}"
-        )
+        return temporal_dims if temporal_dims else None
 
     def bands_dim(self):
         guesses = ["b", "bands"]

--- a/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
+++ b/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
@@ -3,8 +3,6 @@ from typing import Optional
 import odc.geo.xr  # Required for the .geo accessor on xarrays.
 import xarray as xr
 
-from openeo_processes_dask.exceptions import DimensionNotAvailable
-
 
 @xr.register_dataarray_accessor("openeo")
 class OpenEOExtensionDa:

--- a/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
+++ b/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
@@ -12,6 +12,11 @@ class OpenEOExtensionDa:
         self._obj = xarray_obj
 
     @property
+    def spatial_dims(self) -> Optional[str]:
+        spatial_dims = self._obj.odc.spatial_dims
+        return spatial_dims
+
+    @property
     def x_dim(self) -> Optional[str]:
         spatial_dims = self._obj.odc.spatial_dims
         if spatial_dims is not None:
@@ -53,15 +58,15 @@ class OpenEOExtensionDa:
 
         return temporal_dims if temporal_dims else None
 
-    def bands_dim(self):
+    @property
+    def band_dims(self) -> Optional[list]:
         guesses = ["b", "bands"]
 
-        dims = {str(dim) for dim in self._obj.dims}
+        dims = {str(dim).casefold(): str(dim) for dim in self._obj.dims}
 
+        bands_dims = []
         for guess in guesses:
-            if dims.issuperset(guess):
-                return guess
+            if guess in dims:
+                bands_dims.append(dims[guess])
 
-        raise DimensionNotAvailable(
-            f"Unable to identify bands dimension on datacube. Available dimensions: {self._obj.dims}"
-        )
+        return bands_dims if bands_dims else None

--- a/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
+++ b/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
@@ -12,12 +12,20 @@ class OpenEOExtensionDa:
     @property
     def x_dim(self):
         spatial_dims = self._obj.odc.spatial_dims
-        return spatial_dims[1]
+        if spatial_dims is not None:
+            return spatial_dims[1]
+        raise DimensionNotAvailable(
+            f"Unable to identify spatial dimensions on datacube. Available dimensions: {self._obj.dims}"
+        )
 
     @property
     def y_dim(self):
         spatial_dims = self._obj.odc.spatial_dims
-        return spatial_dims[0]
+        if spatial_dims is not None:
+            return spatial_dims[0]
+        raise DimensionNotAvailable(
+            f"Unable to identify spatial dimensions on datacube. Available dimensions: {self._obj.dims}"
+        )
 
     @property
     def z_dim(self):
@@ -34,7 +42,7 @@ class OpenEOExtensionDa:
                 return guess
 
         raise DimensionNotAvailable(
-            f"Datacube has no temporal dimension. Available dimensions: {self._obj.dims}"
+            f"Unable to identify temporal dimension on datacube. Available dimensions: {self._obj.dims}"
         )
 
     def bands_dim(self):
@@ -47,5 +55,5 @@ class OpenEOExtensionDa:
                 return guess
 
         raise DimensionNotAvailable(
-            f"Datacube has no bands dimensions. Available dimensions: {self._obj.dims}"
+            f"Unable to identify bands dimension on datacube. Available dimensions: {self._obj.dims}"
         )

--- a/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
+++ b/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import odc.geo.xr  # Required for the .geo accessor on xarrays.
 import xarray as xr
@@ -10,7 +10,7 @@ class OpenEOExtensionDa:
         self._obj = xarray_obj
 
     @property
-    def spatial_dims(self) -> Optional[str]:
+    def spatial_dims(self) -> Optional[tuple[str, str]]:
         spatial_dims = self._obj.odc.spatial_dims
         return spatial_dims
 
@@ -33,7 +33,7 @@ class OpenEOExtensionDa:
         raise NotImplementedError()
 
     @property
-    def temporal_dims(self) -> Optional[list]:
+    def temporal_dims(self) -> Optional[list[str]]:
         """Find and return all temporal dimensions of the datacube as a list."""
         guesses = [
             "time",
@@ -57,7 +57,7 @@ class OpenEOExtensionDa:
         return temporal_dims if temporal_dims else None
 
     @property
-    def band_dims(self) -> Optional[list]:
+    def band_dims(self) -> Optional[list[str]]:
         guesses = ["b", "bands"]
 
         dims = {str(dim).casefold(): str(dim) for dim in self._obj.dims}

--- a/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
+++ b/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
@@ -1,0 +1,51 @@
+import odc.geo.xr  # Required for the .geo accessor on xarrays.
+import xarray as xr
+
+from openeo_processes_dask.exceptions import DimensionNotAvailable
+
+
+@xr.register_dataarray_accessor("openeo")
+class OpenEOExtensionDa:
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+
+    @property
+    def x_dim(self):
+        spatial_dims = self._obj.odc.spatial_dims
+        return spatial_dims[1]
+
+    @property
+    def y_dim(self):
+        spatial_dims = self._obj.odc.spatial_dims
+        return spatial_dims[0]
+
+    @property
+    def z_dim(self):
+        return NotImplemented()
+
+    @property
+    def time_dim(self):
+        guesses = ["time", "t"]
+
+        dims = {str(dim) for dim in self._obj.dims}
+
+        for guess in guesses:
+            if dims.issuperset(guess):
+                return guess
+
+        raise DimensionNotAvailable(
+            f"Datacube has no temporal dimension. Available dimensions: {self._obj.dims}"
+        )
+
+    def bands_dim(self):
+        guesses = ["b", "bands"]
+
+        dims = {str(dim) for dim in self._obj.dims}
+
+        for guess in guesses:
+            if dims.issuperset(guess):
+                return guess
+
+        raise DimensionNotAvailable(
+            f"Datacube has no bands dimensions. Available dimensions: {self._obj.dims}"
+        )

--- a/openeo_processes_dask/process_implementations/cubes/aggregate.py
+++ b/openeo_processes_dask/process_implementations/cubes/aggregate.py
@@ -129,9 +129,9 @@ def aggregate_spatial(
         geom_crop = data.where(xr_mask).drop(["spatial_ref"], errors="ignore")
         crop_list.append(geom_crop)
 
-        total_count = geom_crop.count(dim=[data.openeo.x_dim, data.openeo.y_dim])
+        total_count = geom_crop.count(dim=data.openeo.spatial_dims)
         valid_count = geom_crop.where(~geom_crop.isnull()).count(
-            dim=[data.openeo.x_dim, data.openeo.y_dim]
+            dim=data.openeo.spatial_dims
         )
         valid_count_list.append(valid_count)
         total_count_list.append(total_count)

--- a/openeo_processes_dask/process_implementations/cubes/aggregate.py
+++ b/openeo_processes_dask/process_implementations/cubes/aggregate.py
@@ -31,7 +31,7 @@ def aggregate_temporal(
     data: RasterCube, intervals: list, reducer: Callable, **kwargs
 ) -> RasterCube:
     if "dimension" not in kwargs:
-        kwargs["dimension"] = "time"
+        kwargs["dimension"] = data.openeo.time_dim
     if not "labels" in kwargs:
         kwargs["labels"] = np.arange(len(kwargs["intervals"]))
     intervals = np.array(kwargs["intervals"])
@@ -68,7 +68,7 @@ def aggregate_temporal_period(
     if period in periods_to_frequency.keys():
         frequency = periods_to_frequency[period]
 
-    resampled_data = data.resample(t=frequency)
+    resampled_data = data.resample({data.openeo.time_dim: frequency})
     return reducer(data=resampled_data, **kwargs)
 
 
@@ -95,12 +95,17 @@ def aggregate_spatial(
         mask = geometry_mask(
             [Geometry(row["geometry"], crs=geometries.crs)], data.geobox, invert=True
         )
-        xr_mask = xr.DataArray(mask, coords=[data.coords["y"], data.coords["x"]])
+        xr_mask = xr.DataArray(
+            mask,
+            coords=[data.coords[data.openeo.y_dim], data.coords[data.openeo.x_dim]],
+        )
         geom_crop = data.where(xr_mask).drop(["spatial_ref"], errors="ignore")
         crop_list.append(geom_crop)
 
-        total_count = geom_crop.count(dim=["x", "y"])
-        valid_count = geom_crop.where(~geom_crop.isnull()).count(dim=["x", "y"])
+        total_count = geom_crop.count(dim=[data.openeo.x_dim, data.openeo.y_dim])
+        valid_count = geom_crop.where(~geom_crop.isnull()).count(
+            dim=[data.openeo.x_dim, data.openeo.y_dim]
+        )
         valid_count_list.append(valid_count)
         total_count_list.append(total_count)
 
@@ -111,7 +116,8 @@ def aggregate_spatial(
 
     xr_crop_list = xr.concat(crop_list, "result")
     xr_crop_list_reduced = reducer(
-        data=reducer(data=xr_crop_list, dimension="x"), dimension="y"
+        data=reducer(data=xr_crop_list, dimension=data.openeo.x_dim),
+        dimension=data.openeo.y_dim,
     )
     xr_crop_list_reduced_ddf = (
         xr_crop_list_reduced.to_dataset(dim="bands")

--- a/openeo_processes_dask/process_implementations/cubes/reduce.py
+++ b/openeo_processes_dask/process_implementations/cubes/reduce.py
@@ -39,4 +39,6 @@ def reduce_spatial(
     data: RasterCube, reducer: Callable, context: Optional[dict] = None, **kwargs
 ) -> RasterCube:
     parameters = {"data": data, "context": context}
-    return reducer(parameters=parameters, dimension=["x", "y"])
+    return reducer(
+        parameters=parameters, dimension=[data.openeo.x_dim, data.openeo.y_dim]
+    )

--- a/openeo_processes_dask/process_implementations/cubes/reduce.py
+++ b/openeo_processes_dask/process_implementations/cubes/reduce.py
@@ -39,6 +39,4 @@ def reduce_spatial(
     data: RasterCube, reducer: Callable, context: Optional[dict] = None, **kwargs
 ) -> RasterCube:
     parameters = {"data": data, "context": context}
-    return reducer(
-        parameters=parameters, dimension=[data.openeo.x_dim, data.openeo.y_dim]
-    )
+    return reducer(parameters=parameters, dimension=data.openeo.spatial_dims)

--- a/openeo_processes_dask/process_implementations/cubes/resample.py
+++ b/openeo_processes_dask/process_implementations/cubes/resample.py
@@ -43,7 +43,9 @@ def resample_cube_spatial(
 
     try:
         # xr_reproject renames the coordinates according to the geobox, this undoes that.
-        resampled_data = resampled_data.rename({"longitude": "x", "latitude": "y"})
+        resampled_data = resampled_data.rename(
+            {"longitude": data.openeo.x_dim, "latitude": data.openeo.y_dim}
+        )
     except ValueError:
         pass
 

--- a/openeo_processes_dask/process_implementations/cubes/utils.py
+++ b/openeo_processes_dask/process_implementations/cubes/utils.py
@@ -5,26 +5,8 @@ from openeo_processes_dask.process_implementations.data_model import RasterCube
 
 logger = logging.getLogger(__name__)
 
-RENAME_DIMS = {
-    "time": "t",
-    "Time": "t",
-    "Bands": "bands",
-    "band": "bands",
-    "latitude": "x",
-    "longitude": "y",
-    "lat": "x",
-    "lon": "y",
-}
-
 
 def _normalise_output_datacube(data) -> RasterCube:
-    # Rename time dimension
-    for old_dim_name, new_dim_name in RENAME_DIMS.items():
-        try:
-            data = data.rename(new_name_or_name_dict={old_dim_name: new_dim_name})
-        except ValueError as e:
-            pass
-
     # Order dimensions for rioxarray
     data = data.transpose("bands", "t", "z", "y", "x", missing_dims="ignore")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ xgboost = "^1.5.1"
 rioxarray = ">=0.12.0,<1"
 odc-algo = ">=0.2.3,<1"
 openeo-pg-parser-networkx = ">=2022.11.0"
+odc-geo = "^0.3.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-import rioxarray as rio  # Required for the .rio accessor on xarrays.

--- a/tests/general_checks.py
+++ b/tests/general_checks.py
@@ -16,6 +16,9 @@ def general_output_checks(
 ):
     assert isinstance(output_cube.data, type(input_cube.data))
 
+    assert input_cube.openeo is not None
+    assert output_cube.openeo is not None
+
     if verify_crs:
         assert input_cube.rio.crs == output_cube.rio.crs
 

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from tests.mockdata import create_fake_rastercube
+
+
+@pytest.mark.parametrize("size", [(6, 5, 4, 4)])
+@pytest.mark.parametrize("dtype", [np.float32])
+def test_openeo_accessor(temporal_interval, bounding_box, random_raster_data):
+    raster_cube = create_fake_rastercube(
+        data=random_raster_data,
+        spatial_extent=bounding_box,
+        temporal_extent=temporal_interval,
+        bands=["B02", "B03", "B04", "B08"],
+    )
+
+    assert raster_cube.openeo is not None
+    assert raster_cube.openeo.x_dim == "x"
+    assert raster_cube.openeo.y_dim == "y"
+    assert raster_cube.openeo.temporal_dims[0] == "t"
+
+    with pytest.raises(NotImplementedError):
+        raster_cube.openeo.z_dim
+
+    raster_cube = raster_cube.rename({"t": "month"})
+    assert raster_cube.openeo.temporal_dims[0] == "month"
+
+    raster_cube = raster_cube.rename({"month": "NotATimeDim"})
+    assert not raster_cube.openeo.temporal_dims

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -18,6 +18,7 @@ def test_openeo_accessor(temporal_interval, bounding_box, random_raster_data):
     assert raster_cube.openeo.x_dim == "x"
     assert raster_cube.openeo.y_dim == "y"
     assert raster_cube.openeo.temporal_dims[0] == "t"
+    assert raster_cube.openeo.band_dims[0] == "bands"
 
     with pytest.raises(NotImplementedError):
         raster_cube.openeo.z_dim
@@ -26,4 +27,10 @@ def test_openeo_accessor(temporal_interval, bounding_box, random_raster_data):
     assert raster_cube.openeo.temporal_dims[0] == "month"
 
     raster_cube = raster_cube.rename({"month": "NotATimeDim"})
-    assert not raster_cube.openeo.temporal_dims
+    assert raster_cube.openeo.temporal_dims is None
+
+    raster_cube = raster_cube.rename({"bands": "b"})
+    assert raster_cube.openeo.band_dims[0] == "b"
+
+    raster_cube = raster_cube.rename({"b": "NotABandDim"})
+    assert raster_cube.openeo.band_dims is None

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from openeo_processes_dask.process_implementations import drop_dimension
 from tests.mockdata import create_fake_rastercube
 
 


### PR DESCRIPTION
Closes https://eodc.atlassian.net/browse/EODCAPI-111

Some comments:
- This is inspired by https://github.com/opendatacube/odc-geo/blob/develop/odc/geo/_xr_interop.py. 
- I've only added an accessor for DataArray, because Dataset isn't really supported atm, will add that later if it turns out to be necessary!
- Should fix the issue @clausmichele raises in https://github.com/Open-EO/openeo-processes-dask/issues/9#issuecomment-1340982555, with assuming that `datacube` was used to load, `odc-geo` enables the `odc` accessor on any xarrays 
- I'll write some tests for this accessor after some initial feedback!
- Will drop process registry from here when this is merged