### PR TITLE
Fix ndvi losing attrs

### DIFF
--- a/openeo_processes_dask/process_implementations/math.py
+++ b/openeo_processes_dask/process_implementations/math.py
@@ -351,4 +351,6 @@ def ndvi(data, nir="nir", red="red", target_band=None):
     nd = (n - r) / (n + r)
     if target_band is not None:
         nd = nd.assign_coords(bands=target_band)
+    # TODO: Remove this once we have the .openeo accessor
+    nd.attrs = data.attrs
     return nd


### PR DESCRIPTION
This made the job referenced in https://discuss.eodc.eu/t/job-queued/520/3 unable to save, because `origin = odc` was getting lost here.