### PR TITLE
fix: Update spatial_ref in resample_spatial

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/merge.py
+++ b/openeo_processes_dask/process_implementations/cubes/merge.py
@@ -22,7 +22,6 @@ def merge_cubes(
     cube2: RasterCube,
     overlap_resolver: Callable = None,
     context: Optional[dict] = None,
-    **kwargs,
 ) -> RasterCube:
 
     if context is None:
@@ -31,6 +30,12 @@ def merge_cubes(
         raise Exception(
             f"Provided cubes have incompatible types. cube1: {type(cube1)}, cube2: {type(cube2)}"
         )
+
+    # TODO: "spatial_ref" isn't guaranteed to be updated correctly throughout all the processes
+    # Therefore ignore it here completely. Get rid of this once we've settled on a mechanism for keeping
+    # track of spatial_ref throughout the process graph.
+    cube1 = cube1.drop("spatial_ref", errors="ignore")
+    cube2 = cube2.drop("spatial_ref", errors="ignore")
 
     # Key: dimension name
     # Value: (labels in cube1 not in cube2, labels in cube2 not in cube1)

--- a/openeo_processes_dask/process_implementations/cubes/merge.py
+++ b/openeo_processes_dask/process_implementations/cubes/merge.py
@@ -31,12 +31,6 @@ def merge_cubes(
             f"Provided cubes have incompatible types. cube1: {type(cube1)}, cube2: {type(cube2)}"
         )
 
-    # TODO: "spatial_ref" isn't guaranteed to be updated correctly throughout all the processes
-    # Therefore ignore it here completely. Get rid of this once we've settled on a mechanism for keeping
-    # track of spatial_ref throughout the process graph.
-    cube1 = cube1.drop("spatial_ref", errors="ignore")
-    cube2 = cube2.drop("spatial_ref", errors="ignore")
-
     # Key: dimension name
     # Value: (labels in cube1 not in cube2, labels in cube2 not in cube1)
     overlap_per_shared_dim = {

--- a/openeo_processes_dask/process_implementations/cubes/resample.py
+++ b/openeo_processes_dask/process_implementations/cubes/resample.py
@@ -49,6 +49,9 @@ def resample_cube_spatial(
 
     resampled_data = odc.algo._warp.xr_reproject(data, target.geobox, resampling=method)
 
+    # odc.algo loses the crs info from rioxarray, so need to rewrite that here.
+    resampled_data.rio.write_crs(target.rio.crs, inplace=True)
+
     try:
         # xr_reproject renames the coordinates according to the geobox, this undoes that.
         resampled_data = resampled_data.rename(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -23,7 +23,7 @@ def test_merge_cubes_type_1(temporal_interval, bounding_box, random_raster_data)
         spatial_extent=bounding_box,
         temporal_extent=temporal_interval,
         bands=["B02", "B03", "B04", "B08"],
-    ).drop("spatial_ref")
+    )
 
     cube_1 = origin_cube.drop_sel({"bands": ["B04", "B08"]})
     cube_2 = origin_cube.drop_sel({"bands": ["B02", "B03"]})
@@ -42,7 +42,7 @@ def test_merge_cubes_type_2(
         spatial_extent=bounding_box,
         temporal_extent=temporal_interval,
         bands=["B01", "B02", "B03"],
-    ).drop("spatial_ref")
+    )
 
     cube_1 = origin_cube.drop_sel({"bands": "B03"})
     cube_2 = origin_cube.drop_sel({"bands": "B01"})
@@ -70,7 +70,7 @@ def test_merge_cubes_type_3(
         spatial_extent=bounding_box,
         temporal_extent=temporal_interval,
         bands=["B01", "B02", "B03"],
-    ).drop("spatial_ref")
+    )
 
     cube_1 = origin_cube
     cube_2 = origin_cube + 1
@@ -104,7 +104,7 @@ def test_merge_cubes_type_4(
         spatial_extent=bounding_box,
         temporal_extent=temporal_interval,
         bands=["B01", "B02", "B03"],
-    ).drop("spatial_ref")
+    )
 
     cube_2 = xr.DataArray(
         np.ones((len(cube_1["x"]), len(cube_1["y"]))),

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -23,7 +23,7 @@ def test_merge_cubes_type_1(temporal_interval, bounding_box, random_raster_data)
         spatial_extent=bounding_box,
         temporal_extent=temporal_interval,
         bands=["B02", "B03", "B04", "B08"],
-    )
+    ).drop("spatial_ref")
 
     cube_1 = origin_cube.drop_sel({"bands": ["B04", "B08"]})
     cube_2 = origin_cube.drop_sel({"bands": ["B02", "B03"]})
@@ -42,7 +42,7 @@ def test_merge_cubes_type_2(
         spatial_extent=bounding_box,
         temporal_extent=temporal_interval,
         bands=["B01", "B02", "B03"],
-    )
+    ).drop("spatial_ref")
 
     cube_1 = origin_cube.drop_sel({"bands": "B03"})
     cube_2 = origin_cube.drop_sel({"bands": "B01"})
@@ -70,7 +70,7 @@ def test_merge_cubes_type_3(
         spatial_extent=bounding_box,
         temporal_extent=temporal_interval,
         bands=["B01", "B02", "B03"],
-    )
+    ).drop("spatial_ref")
 
     cube_1 = origin_cube
     cube_2 = origin_cube + 1
@@ -104,7 +104,7 @@ def test_merge_cubes_type_4(
         spatial_extent=bounding_box,
         temporal_extent=temporal_interval,
         bands=["B01", "B02", "B03"],
-    )
+    ).drop("spatial_ref")
 
     cube_2 = xr.DataArray(
         np.ones((len(cube_1["x"]), len(cube_1["y"]))),


### PR DESCRIPTION
"spatial_ref" isn't guaranteed to be updated correctly throughout all the processes, therefore ignore it here completely. Get rid of this once we've settled on a mechanism for keeping track of spatial_ref throughout the process graph.