### PR TITLE
Remove `scale` process from math.py

### DIFF
--- a/openeo_processes_dask/process_implementations/math.py
+++ b/openeo_processes_dask/process_implementations/math.py
@@ -49,7 +49,6 @@ __all__ = [
     "artanh",
     "arctan2",
     "linear_scale_range",
-    "scale",
     "mod",
     "absolute",
     "sgn",
@@ -232,11 +231,6 @@ def arctan2(y, x):
 def linear_scale_range(x, inputMin, inputMax, outputMin=0.0, outputMax=1.0):
     lsr = ((x - inputMin) / (inputMax - inputMin)) * (outputMax - outputMin) + outputMin
     return lsr
-
-
-def scale(x, factor=1.0):
-    s = x * factor
-    return s
 
 
 def mod(x, y):


### PR DESCRIPTION
I do not know where the `scale` process initially came from, but it does not belong to the official `openeo processes` and it is basically equivalent to the `multiply` process. What do you think about removing it from the processes? Is there any reason to keep it? :) 