### PR TITLE
chore: bump parser version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dask-geopandas = { version = ">=0.2.0,<1", optional = true }
 xgboost = { version = "^1.5.1", optional = true }
 rioxarray = { version = ">=0.12.0,<1", optional = true }
 odc-algo = { version = "==0.2.3", optional = true }
-openeo-pg-parser-networkx = { version = ">=2023.1.2", optional = true }
+openeo-pg-parser-networkx = { version = ">=2023.3.0", optional = true }
 odc-geo = { version = "^0.3.2", optional = true }
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This will get rid of the dependency on matplotlib.