### PR TITLE
chore: bump pg parser to 2023.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dask-geopandas = { version = ">=0.2.0,<1", optional = true }
 xgboost = { version = "^1.5.1", optional = true }
 rioxarray = { version = ">=0.12.0,<1", optional = true }
 odc-algo = { version = "==0.2.3", optional = true }
-openeo-pg-parser-networkx = { version = ">=2023.3.1", optional = true }
+openeo-pg-parser-networkx = { version = ">=2023.5.1", optional = true }
 odc-geo = { version = "^0.3.2", optional = true }
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
closes #110 