### PR TITLE
chore: bump dask to 2023.4.0 to remove constraint on bokeh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [
 python = ">=3.9,<3.12"
 geopandas = { version = ">=0.11.1,<1", optional = true }
 xarray = { version = ">=2022.11.0", optional = true }
-dask = {extras = ["array"], version = ">=2022.11.1", optional = true}
+dask = {extras = ["array"], version = ">=2023.4.0", optional = true}
 rasterio = { version = "^1.3.4", optional = true }
 dask-geopandas = { version = ">=0.2.0,<1", optional = true }
 xgboost = { version = "^1.5.1", optional = true }
@@ -45,7 +45,6 @@ ipykernel = "^6.15.1"
 matplotlib = "^3.5.3"
 folium = ">=0.12.1,<1"
 mapclassify = "^2.4.3"
-bokeh = "<3"
 pre-commit = "^2.20.0"
 pytest-cov = "^4.0.0"
 


### PR DESCRIPTION
We've had to pin bokeh to "<3" because of https://github.com/dask/distributed/pull/7413. This was fixed in dask 2023.4.0, therefore I think it's time to bump the required dask version for this project and remove the bokeh pin. Moreover this silences a warning on the test suite.