### PR TITLE
feat: add fit_curve and predict_curve

### DIFF
--- a/openeo_processes_dask/process_implementations/core.py
+++ b/openeo_processes_dask/process_implementations/core.py
@@ -44,25 +44,14 @@ def process(f):
         resolved_args = []
         resolved_kwargs = {}
 
-        already_resolved_params = []
         # If an arg is specified in positional_parameters, put the correct key-value pair into named_parameters
         for arg_name, i in positional_parameters.items():
-            if isinstance(i, slice):
-                for n, arg_in_slice in enumerate(args[i]):
-                    resolved_args.insert(i.start + n, arg_in_slice)
-            else:
-                resolved_args.insert(i, args[i])
-            already_resolved_params.append(arg_name)
+            named_parameters[arg_name] = args[i]
 
         for arg in args:
             if isinstance(arg, ParameterReference):
-                if (
-                    arg.from_parameter in named_parameters
-                    and arg.from_parameter not in already_resolved_params
-                ):
+                if arg.from_parameter in named_parameters:
                     resolved_args.append(named_parameters[arg.from_parameter])
-                elif arg.from_parameter in already_resolved_params:
-                    continue
                 else:
                     raise ProcessParameterMissing(
                         f"Error: Process Parameter {arg.from_parameter} was missing for process {f.__name__}"
@@ -72,8 +61,6 @@ def process(f):
             if isinstance(arg, ParameterReference):
                 if arg.from_parameter in named_parameters:
                     resolved_kwargs[k] = named_parameters[arg.from_parameter]
-                elif arg.from_parameter in already_resolved_params:
-                    continue
                 else:
                     raise ProcessParameterMissing(
                         f"Error: Process Parameter {arg.from_parameter} was missing for process {f.__name__}"

--- a/openeo_processes_dask/process_implementations/ml/__init__.py
+++ b/openeo_processes_dask/process_implementations/ml/__init__.py
@@ -1,1 +1,2 @@
+from .curve_fitting import *
 from .random_forest import *

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -26,7 +26,7 @@ def fit_curve(data: RasterCube, parameters: list, function: Callable, dimension:
     # so we do this to generate names locally
     parameters = {f"param_{i}": v for i, v in enumerate(parameters)}
 
-    # The dimension along which to predict cannot be chunked!
+    # The dimension along which to fit the curves cannot be chunked!
     rechunked_data = data.chunk({dimension: -1})
 
     def wrapper(f):

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -34,9 +34,17 @@ def fit_curve(data: RasterCube, parameters: list, function: Callable, dimension:
 
     # .curvefit returns some extra information that isn't required by the OpenEO process
     # so we simply drop these here.
-    fit_result = rechunked_data.curvefit(
-        dimension, wrapper(function), p0=parameters, param_names=list(parameters.keys())
-    ).drop_dims(["cov_i", "cov_j"])
+    fit_result = (
+        rechunked_data.curvefit(
+            dimension,
+            wrapper(function),
+            p0=parameters,
+            param_names=list(parameters.keys()),
+        )
+        .drop_dims(["cov_i", "cov_j"])
+        .to_array()
+        .squeeze()
+    )
     return fit_result
 
 

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -57,6 +57,8 @@ def fit_curve(data: RasterCube, parameters: list, function: Callable, dimension:
         .transpose(*expected_dims_after)
     )
 
+    fit_result.attrs = data.attrs
+
     return fit_result
 
 

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+from openeo_processes_dask.process_implementations.cubes import apply_dimension
 from openeo_processes_dask.process_implementations.data_model import RasterCube
 from openeo_processes_dask.process_implementations.exceptions import (
     DimensionNotAvailable,
@@ -29,5 +30,12 @@ def fit_curve(data: RasterCube, parameters: list, function: Callable, dimension:
     return fit_result
 
 
-def predict_curve():
+def predict_curve(
+    data: RasterCube,
+    function: Callable,
+    parameters: RasterCube,
+    dimension: str,
+    labels: list,
+):
+    # TODO: constrain prediction to nodata values
     pass

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -1,0 +1,23 @@
+from openeo_processes_dask.process_implementations.data_model import RasterCube
+from openeo_processes_dask.process_implementations.exceptions import (
+    DimensionNotAvailable,
+)
+
+__all__ = ["fit_curve", "predict_curve"]
+
+
+def fit_curve(data: RasterCube, parameters, function, dimension):
+    if dimension not in data.dims:
+        raise DimensionNotAvailable(
+            f"Provided dimension ({dimension}) not found in data.dims: {data.dims}"
+        )
+
+    rechunked_data = data.chunk({dimension: -1})
+    fit_result = rechunked_data.curvefit(dimension, function, p0=parameters).drop_dims(
+        ["cov_i", "cov_j"]
+    )
+    return fit_result
+
+
+def predict_curve():
+    pass

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -14,7 +14,13 @@ from openeo_processes_dask.process_implementations.exceptions import (
 __all__ = ["fit_curve", "predict_curve"]
 
 
-def fit_curve(data: RasterCube, parameters: list, function: Callable, dimension: str):
+def fit_curve(
+    data: RasterCube,
+    parameters: list,
+    function: Callable,
+    dimension: str,
+    ignore_nodata: bool = True,
+):
     if dimension not in data.dims:
         raise DimensionNotAvailable(
             f"Provided dimension ({dimension}) not found in data.dims: {data.dims}"
@@ -50,6 +56,7 @@ def fit_curve(data: RasterCube, parameters: list, function: Callable, dimension:
             wrapper(function),
             p0=parameters,
             param_names=list(parameters.keys()),
+            skipna=ignore_nodata,
         )
         .drop_dims(["cov_i", "cov_j"])
         .to_array()

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -6,16 +6,18 @@ from openeo_processes_dask.process_implementations.exceptions import (
 __all__ = ["fit_curve", "predict_curve"]
 
 
-def fit_curve(data: RasterCube, parameters, function, dimension):
+def fit_curve(data: RasterCube, parameters: list, function, dimension):
+    parameters = {f"param_{i}": v for i, v in enumerate(parameters)}
+
     if dimension not in data.dims:
         raise DimensionNotAvailable(
             f"Provided dimension ({dimension}) not found in data.dims: {data.dims}"
         )
 
     rechunked_data = data.chunk({dimension: -1})
-    fit_result = rechunked_data.curvefit(dimension, function, p0=parameters).drop_dims(
-        ["cov_i", "cov_j"]
-    )
+    fit_result = rechunked_data.curvefit(
+        dimension, function, p0=parameters, param_names=list(parameters.keys())
+    ).drop_dims(["cov_i", "cov_j"])
     return fit_result
 
 

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -64,10 +64,16 @@ def predict_curve(
     parameters: RasterCube,
     function: Callable,
     dimension: str,
-    labels: Optional[ArrayLike] = None,
+    labels: ArrayLike,
 ):
     labels_were_datetime = False
     dims_before = list(parameters.dims)
+
+    try:
+        # Try parsing as datetime first
+        labels = np.asarray(labels, dtype=np.datetime64)
+    except ValueError:
+        labels = np.asarray(labels)
 
     if np.issubdtype(labels.dtype, np.datetime64):
         labels = labels.astype(int)

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -58,7 +58,6 @@ def predict_curve(
     dimension: str,
     labels: Optional[ArrayLike] = None,
 ):
-    # parameters: (x, y, bands, param)
     if np.issubdtype(labels.dtype, np.datetime64):
         labels = labels.astype(int)
 
@@ -80,7 +79,7 @@ def predict_curve(
         input_core_dims=[["param"]],
         output_core_dims=[[dimension]],
         dask="parallelized",
-        output_dtypes=[np.float32],
+        output_dtypes=[np.float64],
         dask_gufunc_kwargs={
             "allow_rechunk": True,
             "output_sizes": {dimension: len(labels)},

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from openeo_processes_dask.process_implementations.data_model import RasterCube
 from openeo_processes_dask.process_implementations.exceptions import (
     DimensionNotAvailable,
@@ -6,15 +8,21 @@ from openeo_processes_dask.process_implementations.exceptions import (
 __all__ = ["fit_curve", "predict_curve"]
 
 
-def fit_curve(data: RasterCube, parameters: list, function, dimension):
-    parameters = {f"param_{i}": v for i, v in enumerate(parameters)}
-
+def fit_curve(data: RasterCube, parameters: list, function: Callable, dimension: str):
     if dimension not in data.dims:
         raise DimensionNotAvailable(
             f"Provided dimension ({dimension}) not found in data.dims: {data.dims}"
         )
 
+    # In the spec, parameters is a list, but xr.curvefit requires names for them,
+    # so we do this to generate names locally
+    parameters = {f"param_{i}": v for i, v in enumerate(parameters)}
+
+    # The dimension along which to predict cannot be chunked!
     rechunked_data = data.chunk({dimension: -1})
+
+    # .curvefit returns some extra information that isn't required by the OpenEO process
+    # so we simply drop these here.
     fit_result = rechunked_data.curvefit(
         dimension, function, p0=parameters, param_names=list(parameters.keys())
     ).drop_dims(["cov_i", "cov_j"])

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -64,6 +64,7 @@ def predict_curve(
         labels = labels.astype(int)
         labels_were_datetime = True
 
+    # This is necessary to pipe the arguments correctly through @process
     def wrapper(f):
         def _wrap(*args, **kwargs):
             return f(

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,7 +1,17 @@
-import geopandas as gpd
-import xgboost as xgb
+from functools import partial
 
-from openeo_processes_dask.process_implementations.ml import fit_regr_random_forest
+import geopandas as gpd
+import numpy as np
+import pytest
+import xgboost as xgb
+from openeo_pg_parser_networkx.pg_schema import ParameterReference
+
+from openeo_processes_dask.process_implementations.cubes.apply import apply_dimension
+from openeo_processes_dask.process_implementations.ml import (
+    fit_curve,
+    fit_regr_random_forest,
+)
+from tests.mockdata import create_fake_rastercube
 
 
 def test_fit_regr_random_forest(vector_data_cube, dask_client):
@@ -32,3 +42,23 @@ def test_fit_regr_random_forest_inline_geojson(
     )
 
     assert isinstance(model, xgb.core.Booster)
+
+
+@pytest.mark.parametrize("size", [(6, 5, 4, 3)])
+@pytest.mark.parametrize("dtype", [np.float64])
+def test_fit_curve(
+    temporal_interval, bounding_box, random_raster_data, process_registry
+):
+    origin_cube = create_fake_rastercube(
+        data=random_raster_data,
+        spatial_extent=bounding_box,
+        temporal_extent=temporal_interval,
+        bands=["B02", "B03", "B04"],
+        backend="dask",
+    )
+
+    def fitFunction(t, a, b, c):
+        t0 = 2 * np.pi / 31557600 * t
+        return a + b * np.cos(t0) + c * np.sin(t0)
+
+    result = fit_curve(origin_cube, parameters={}, function=fitFunction, dimension="t")

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -70,9 +70,15 @@ def test_curve_fitting(
         parameters=ParameterReference(from_parameter="parameters"),
     )
 
+    parameters = [1, 0, 0]
     result = fit_curve(
-        origin_cube, parameters=[0, 0, 0], function=_process, dimension="t"
+        origin_cube, parameters=parameters, function=_process, dimension="t"
     )
     assert len(result.param) == 3
-    assert isinstance(result.to_array().data, dask.array.Array)
+    assert isinstance(result.data, dask.array.Array)
     output = result.compute()
+
+    assert len(output.coords["bands"]) == len(origin_cube.coords["bands"])
+    assert len(output.coords["x"]) == len(origin_cube.coords["x"])
+    assert len(output.coords["y"]) == len(origin_cube.coords["y"])
+    assert len(output.coords["param"]) == len(parameters)

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import dask
 import geopandas as gpd
 import numpy as np
 import pytest
@@ -73,3 +74,4 @@ def test_fit_curve(
         origin_cube, parameters=[0, 0, 0], function=_process, dimension="t"
     )
     assert len(result.param) == 3
+    assert isinstance(result.to_array().data, dask.array.Array)

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -86,5 +86,7 @@ def test_curve_fitting(temporal_interval, bounding_box, random_raster_data):
         result,
         _process,
         origin_cube.openeo.temporal_dims[0],
-        labels=dimension_labels(origin_cube, "t"),
+        labels=dimension_labels(origin_cube, origin_cube.openeo.temporal_dims[0]),
     ).compute()
+
+    assert True

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -60,7 +60,7 @@ def test_curve_fitting(
     )
 
     @process
-    def fitFunction(x, parameters):
+    def fitFunction(x, *parameters):
         t0 = 2 * np.pi / 31557600 * x
         return parameters[0] + parameters[1] * np.cos(t0) + parameters[2] * np.sin(t0)
 
@@ -75,3 +75,4 @@ def test_curve_fitting(
     )
     assert len(result.param) == 3
     assert isinstance(result.to_array().data, dask.array.Array)
+    result.compute()

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -12,6 +12,7 @@ from openeo_processes_dask.process_implementations.cubes.apply import apply_dime
 from openeo_processes_dask.process_implementations.ml import (
     fit_curve,
     fit_regr_random_forest,
+    predict_curve,
 )
 from tests.mockdata import create_fake_rastercube
 
@@ -82,3 +83,7 @@ def test_curve_fitting(
     assert len(output.coords["x"]) == len(origin_cube.coords["x"])
     assert len(output.coords["y"]) == len(origin_cube.coords["y"])
     assert len(output.coords["param"]) == len(parameters)
+
+    predictions = predict_curve(
+        origin_cube, _process, output, origin_cube.openeo.temporal_dims[0]
+    )

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -48,7 +48,7 @@ def test_fit_regr_random_forest_inline_geojson(
 
 @pytest.mark.parametrize("size", [(6, 5, 4, 3)])
 @pytest.mark.parametrize("dtype", [np.float64])
-def test_fit_curve(
+def test_curve_fitting(
     temporal_interval, bounding_box, random_raster_data, process_registry
 ):
     origin_cube = create_fake_rastercube(

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -82,11 +82,13 @@ def test_curve_fitting(temporal_interval, bounding_box, random_raster_data):
     assert len(result.coords["y"]) == len(origin_cube.coords["y"])
     assert len(result.coords["param"]) == len(parameters)
 
+    labels = dimension_labels(origin_cube, origin_cube.openeo.temporal_dims[0])
     predictions = predict_curve(
         result,
         _process,
         origin_cube.openeo.temporal_dims[0],
-        labels=dimension_labels(origin_cube, origin_cube.openeo.temporal_dims[0]),
+        labels=labels,
     ).compute()
 
-    assert True
+    assert len(predictions.coords[origin_cube.openeo.temporal_dims[0]]) == len(labels)
+    assert "param" not in predictions.dims

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -70,6 +70,6 @@ def test_fit_curve(
     )
 
     result = fit_curve(
-        origin_cube, parameters=[0, 0, 0], function=fitFunction, dimension="t"
+        origin_cube, parameters=[0, 0, 0], function=_process, dimension="t"
     )
     assert len(result.param) == 3

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -60,7 +60,7 @@ def test_curve_fitting(
     )
 
     @process
-    def fitFunction(x, *parameters):
+    def fitFunction(x, parameters):
         t0 = 2 * np.pi / 31557600 * x
         return parameters[0] + parameters[1] * np.cos(t0) + parameters[2] * np.sin(t0)
 
@@ -75,4 +75,4 @@ def test_curve_fitting(
     )
     assert len(result.param) == 3
     assert isinstance(result.to_array().data, dask.array.Array)
-    result.compute()
+    output = result.compute()


### PR DESCRIPTION
I've now taken a shot at implementing `fit_curve` too, and thought I'd just start from scratch to see what the problem really is. With just the xarray built-in function `curvefit`, I get throughput of 1000pixels/sec with a vanilla OpenEO dask cluster (6 workers w/ 4CPUs and 12GB RAM each). Dask has added constant memory rechunking a while ago with their [P2P rechunking scheme](https://discourse.pangeo.io/t/rechunking-large-data-at-constant-memory-in-dask-experimental/3266), so I'm somewhat hopeful that this will be okay for larger datacubes too. I haven't tried a truly humonguous dataset yet (the largest I tried was 1million pixels, 2x of what was used in [the SRR2 notebook](https://github.com/openEOPlatform/SRR2_notebooks/blob/main/UC6%20-%20Forest%20Dynamics.ipynb), which took 30 minutes), but I'm inclined to not worry about the rechunking anymore unless it comes up again.

@clausmichele do you think this level of performance allows you to make progress on this usecase?

There's some open questions about the interface:
- I don't think `fit_curve` should be run through `apply_dimension` or `reduce_dimension`, as was changed in https://github.com/Open-EO/openeo-processes/issues/425, because this makes everything awkward. I've therefore added the `dimension` parameter back in.
- I don't know how to support `ignore_nodata` right now
- The inference (`predict_curve`) is fine to run as a reducer though! I haven't had a chance to take a closer look though, so might need changes there too!

The parameter unpacking I've only kind of eyeballed so far, could use a closer look to confirm that what I'm doing there makes sense!

Note on performance: Most of the wall time is spent in a `vectorize__wrapper` step - afaict this is where `apply_ufunc` vectorizes the function before passing it to scipy's curve_fit, and this work isn't parallelising. I've already tried pre-compiling the function with numba before, but to no avail. Not entirely sure how we'd go about speeding this up further, but maybe the current throughput is already good enough to demonstrate the usecase?
![image](https://github.com/Open-EO/openeo-processes-dask/assets/17790923/a6a5a6ed-a2e4-4fa7-a441-55df5dcb5428)
