### PR TITLE
fix: special case for filter_temporal

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/_filter.py
+++ b/openeo_processes_dask/process_implementations/cubes/_filter.py
@@ -68,7 +68,7 @@ def filter_temporal(
         ]
     except:
         try:
-            data = data.where(~np.isnat(data.time), drop=True)
+            data = data.where(~np.isnat(data[applicable_temporal_dimension]), drop=True)
             filtered = data.loc[
                 {applicable_temporal_dimension: slice(start_time, end_time)}
             ]

--- a/openeo_processes_dask/process_implementations/cubes/_filter.py
+++ b/openeo_processes_dask/process_implementations/cubes/_filter.py
@@ -62,18 +62,10 @@ def filter_temporal(
         # The specified instance in time is excluded from the interval.
         # See https://processes.openeo.org/#filter_temporal
 
-    try:
+        data = data.where(~np.isnat(data[applicable_temporal_dimension]), drop=True)
         filtered = data.loc[
             {applicable_temporal_dimension: slice(start_time, end_time)}
         ]
-    except:
-        try:
-            data = data.where(~np.isnat(data[applicable_temporal_dimension]), drop=True)
-            filtered = data.loc[
-                {applicable_temporal_dimension: slice(start_time, end_time)}
-            ]
-        except Exception as e:
-            raise e
 
     return filtered
 

--- a/openeo_processes_dask/process_implementations/cubes/_filter.py
+++ b/openeo_processes_dask/process_implementations/cubes/_filter.py
@@ -62,24 +62,6 @@ def filter_temporal(
         # The specified instance in time is excluded from the interval.
         # See https://processes.openeo.org/#filter_temporal
 
-    def nearest_lower(items, timestamp):  # x must be >= timestamp
-        deltas = [abs(x - timestamp) for x in timestamps]
-        closest = min(deltas)
-        idx = deltas.index(closest)
-        closest_t = items[idx]
-        if closest_t < timestamp:
-            closest_t = items[idx + 1]
-        return closest_t
-
-    def nearest_upper(items, timestamp):  # x must be <= timestamp
-        deltas = [abs(x - timestamp) for x in timestamps]
-        closest = min(deltas)
-        idx = deltas.index(closest)
-        closest_t = items[idx]
-        if closest_t > timestamp:
-            closest_t = items[idx - 1]
-        return closest_t
-
     timestamps = data[applicable_temporal_dimension].values
     # If the timestamps along the temporal dimensions are not equally spaced the simple slice will fail
     # Therefore we need to find firstly exactly what are the closest timestamps available and use them
@@ -89,14 +71,13 @@ def filter_temporal(
             {applicable_temporal_dimension: slice(start_time, end_time)}
         ]
     except:
-        filtered = data.loc[
-            {
-                applicable_temporal_dimension: slice(
-                    nearest_lower(timestamps, start_time),
-                    nearest_upper(timestamps, end_time),
-                )
-            }
-        ]
+        try:
+            data = data.where(~np.isnat(data.time), drop=True)
+            filtered = data.loc[
+                {applicable_temporal_dimension: slice(start_time, end_time)}
+            ]
+        except Exception as e:
+            raise e
 
     return filtered
 

--- a/openeo_processes_dask/process_implementations/cubes/_filter.py
+++ b/openeo_processes_dask/process_implementations/cubes/_filter.py
@@ -62,10 +62,6 @@ def filter_temporal(
         # The specified instance in time is excluded from the interval.
         # See https://processes.openeo.org/#filter_temporal
 
-    timestamps = data[applicable_temporal_dimension].values
-    # If the timestamps along the temporal dimensions are not equally spaced the simple slice will fail
-    # Therefore we need to find firstly exactly what are the closest timestamps available and use them
-    # for slicing
     try:
         filtered = data.loc[
             {applicable_temporal_dimension: slice(start_time, end_time)}

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,6 +1,8 @@
+import copy
 from functools import partial
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 from openeo_pg_parser_networkx.pg_schema import ParameterReference, TemporalInterval
@@ -58,6 +60,11 @@ def test_filter_temporal(temporal_interval, bounding_box, random_raster_data):
         output_cube,
         input_cube.loc[dict(t=slice("2018-05-01T00:00:00", "2018-05-02T23:59:59"))],
     )
+
+    new_coords = list(copy.deepcopy(input_cube.coords["t"].data))
+    new_coords[1] = pd.NaT
+    invalid_input_cube = input_cube.assign_coords({"t": np.array(new_coords)})
+    filter_temporal(invalid_input_cube, temporal_interval)
 
 
 @pytest.mark.parametrize("size", [(1, 1, 1, 2)])


### PR DESCRIPTION
I found a special case when `filter_temporal` fails with 
`KeyError: Timestamp('2022-05-10 00:00:00')`

It is probably due to some not conform elements in the temporal dimension.

```python
import openeo
from openeo.local import LocalConnection
local_conn = LocalConnection('')


url = "https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"
spatial_extent = {"west": 11.1, "east": 11.5, "south": 46.1, "north": 46.5}
datacube = local_conn.load_stac(url=url,
                    spatial_extent=spatial_extent)
temporal_extent = ['2022-05-10T00:00:00','2022-06-30T00:00:00']
temporal_slice = datacube.filter_temporal(temporal_extent)
temporal_slice.execute()
```

This PR fixes that special case.

@LukeWeidenwalker could you try that code and confirm that with this PR it solves the issue for you as well? You would need to install the latest openeo-python-client from source, since the one with load_stac it's not released yet.

I actually tried to create a test to reproduce this special case but I didn't manage to reproduce it.