### PR TITLE
fix: handle incompatible coords in merge_cubes

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/merge.py
+++ b/openeo_processes_dask/process_implementations/cubes/merge.py
@@ -113,6 +113,8 @@ def merge_cubes(
                     cube1 = cube1.to_dataset(cube1.openeo.band_dims[0])
                     cube2 = cube2.to_dataset(cube2.openeo.band_dims[0])
 
+                # compat="override" to deal with potentially conflicting coords
+                # see https://github.com/Open-EO/openeo-processes-dask/pull/148 for context
                 merged_cube = xr.combine_by_coords(
                     [cube1, cube2], combine_attrs="drop_conflicts", compat="override"
                 )

--- a/openeo_processes_dask/process_implementations/cubes/merge.py
+++ b/openeo_processes_dask/process_implementations/cubes/merge.py
@@ -112,24 +112,10 @@ def merge_cubes(
                     ]
                     cube1 = cube1.to_dataset(cube1.openeo.band_dims[0])
                     cube2 = cube2.to_dataset(cube2.openeo.band_dims[0])
-                try:
-                    merged_cube = xr.combine_by_coords(
-                        [cube1, cube2], combine_attrs="drop_conflicts"
-                    )
-                except:
-                    to_drop = []
-                    for d in cube1.coords:
-                        if d not in cube1.dims:
-                            to_drop.append(d)
-                    cube1 = cube1.drop(to_drop)
-                    to_drop = []
-                    for d in cube2.coords:
-                        if d not in cube2.dims:
-                            to_drop.append(d)
-                    cube2 = cube2.drop(to_drop)
-                    merged_cube = xr.combine_by_coords(
-                        [cube1, cube2], combine_attrs="drop_conflicts"
-                    )
+
+                merged_cube = xr.combine_by_coords(
+                    [cube1, cube2], combine_attrs="drop_conflicts", compat="override"
+                )
                 if isinstance(merged_cube, xr.Dataset):
                     merged_cube = merged_cube.to_array(dim="bands")
                     merged_cube = merged_cube.reindex({"bands": previous_band_order})

--- a/openeo_processes_dask/process_implementations/cubes/merge.py
+++ b/openeo_processes_dask/process_implementations/cubes/merge.py
@@ -112,10 +112,24 @@ def merge_cubes(
                     ]
                     cube1 = cube1.to_dataset(cube1.openeo.band_dims[0])
                     cube2 = cube2.to_dataset(cube2.openeo.band_dims[0])
-
-                merged_cube = xr.combine_by_coords(
-                    [cube1, cube2], combine_attrs="drop_conflicts"
-                )
+                try:
+                    merged_cube = xr.combine_by_coords(
+                        [cube1, cube2], combine_attrs="drop_conflicts"
+                    )
+                except:
+                    to_drop = []
+                    for d in cube1.coords:
+                        if d not in cube1.dims:
+                            to_drop.append(d)
+                    cube1 = cube1.drop(to_drop)
+                    to_drop = []
+                    for d in cube2.coords:
+                        if d not in cube2.dims:
+                            to_drop.append(d)
+                    cube2 = cube2.drop(to_drop)
+                    merged_cube = xr.combine_by_coords(
+                        [cube1, cube2], combine_attrs="drop_conflicts"
+                    )
                 if isinstance(merged_cube, xr.Dataset):
                     merged_cube = merged_cube.to_array(dim="bands")
                     merged_cube = merged_cube.reindex({"bands": previous_band_order})

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -149,9 +149,10 @@ def test_merge_cubes_type_4(
 
 @pytest.mark.parametrize("size", [(6, 5, 4, 1)])
 @pytest.mark.parametrize("dtype", [np.float64])
-def test_merge_cubes_type_5(
+def test_conflicting_coords(
     temporal_interval, bounding_box, random_raster_data, process_registry
 ):
+    # See https://github.com/Open-EO/openeo-processes-dask/pull/148 for why is is necessary
     # This is basically broadcasting the smaller datacube and then applying the overlap resolver.
     cube_1 = create_fake_rastercube(
         data=random_raster_data,

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -145,3 +145,31 @@ def test_merge_cubes_type_4(
 
     assert isinstance(merged_cube_2.data, dask.array.Array)
     xr.testing.assert_equal(merged_cube_2, cube_1 + 1)
+
+
+@pytest.mark.parametrize("size", [(6, 5, 4, 1)])
+@pytest.mark.parametrize("dtype", [np.float64])
+def test_merge_cubes_type_5(
+    temporal_interval, bounding_box, random_raster_data, process_registry
+):
+    # This is basically broadcasting the smaller datacube and then applying the overlap resolver.
+    cube_1 = create_fake_rastercube(
+        data=random_raster_data,
+        spatial_extent=bounding_box,
+        temporal_extent=temporal_interval,
+        bands=["B01"],
+        backend="dask",
+    )
+    cube_1["s2:processing_baseline"] = "05.8"
+    cube_2 = create_fake_rastercube(
+        data=random_raster_data,
+        spatial_extent=bounding_box,
+        temporal_extent=temporal_interval,
+        bands=["B02"],
+        backend="dask",
+    )
+    cube_2["s2:processing_baseline"] = "05.9"
+
+    merged_cube_1 = merge_cubes(cube_1, cube_2)
+
+    assert isinstance(merged_cube_1.data, dask.array.Array)


### PR DESCRIPTION
@LukeWeidenwalker, in load_stac, stackstac loads many additional metadata as data variables/coordinates. It is an advantage when we want to have a complete overview on the dataset but in this case creates an issue when trying to merge different datasets, An example is in this notebook I recently created:
https://github.com/clausmichele/openeo-python-client/blob/add_stac_notebook/examples/notebooks/Client_Side_Processing/client_side_processing_STAC_data_fusion.ipynb

This fix removes the unnecessary coordinates if the merge fails and tries to merge the datacubes again. I spent a lot of time trying to find a more elegant solution, but I couldn't.