### PR TITLE
Draft for labelled arrays

### DIFF
--- a/openeo_processes_dask/process_implementations/arrays.py
+++ b/openeo_processes_dask/process_implementations/arrays.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from numpy.typing import ArrayLike
+from openeo_pg_parser_networkx.pg_schema import DateTime
 from xarray.core.duck_array_ops import isnull, notnull
 
 from openeo_processes_dask.process_implementations.cubes.utils import _is_dask_array
@@ -42,6 +43,8 @@ def array_element(
     label: Optional[str] = None,
     return_nodata: Optional[bool] = False,
     axis=None,
+    context=None,
+    dim_labels=None,
 ):
     if index is None and label is None:
         raise ArrayElementParameterMissing(
@@ -54,14 +57,20 @@ def array_element(
         )
 
     if label is not None:
-        raise NotImplementedError(
-            "labelled arrays are currently not implemented. Please use index instead."
-        )
+        if isinstance(label, DateTime):
+            label = label.to_numpy()
+        (index,) = np.where(dim_labels == label)
+        if len(index) == 0:
+            index = None
+        else:
+            index = index[0]
 
     try:
         if index is not None:
             element = np.take(data, index, axis=axis)
             return element
+        else:
+            raise IndexError
     except IndexError:
         if return_nodata:
             logger.warning(

--- a/openeo_processes_dask/process_implementations/cubes/reduce.py
+++ b/openeo_processes_dask/process_implementations/cubes/reduce.py
@@ -21,15 +21,16 @@ def reduce_dimension(
             f"Provided dimension ({dimension}) not found in data.dims: {data.dims}"
         )
 
-    positional_parameters = {"data": 0}
-    named_parameters = {"context": context}
+    dim_labels = data[dimension].values
 
+    positional_parameters = {"data": 0}
     reduced_data = data.reduce(
         reducer,
         dim=dimension,
         keep_attrs=True,
         positional_parameters=positional_parameters,
-        named_parameters=named_parameters,
+        context=context,
+        dim_labels=dim_labels,
     )
 
     # Preset

--- a/openeo_processes_dask/process_implementations/math.py
+++ b/openeo_processes_dask/process_implementations/math.py
@@ -85,12 +85,12 @@ def constant(x):
     return x
 
 
-def divide(x, y):
+def divide(x, y, **kwargs):
     result = x / y
     return result
 
 
-def subtract(x, y):
+def subtract(x, y, **kwargs):
     result = x - y
     return result
 
@@ -100,7 +100,7 @@ def multiply(x, y):
     return result
 
 
-def add(x, y):
+def add(x, y, **kwargs):
     result = x + y
     return result
 


### PR DESCRIPTION
First draft to support labelled arrays.

I modified only the processes required to run the following simple example. We would have to go through all the math processes and others as well if we want to implement this.

```python
from openeo.local import LocalConnection
from openeo.processes import pi
local_conn = LocalConnection("./")

url = "https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"
spatial_extent =  {"east": 11.40, "north": 46.52, "south": 46.46, "west": 11.25}
temporal_extent = ["2022-06-01", "2022-06-30"]
bands = ["red", "nir"]
properties = {"eo:cloud_cover": dict(lt=80)}
s2_datacube = local_conn.load_stac(
    url=url,
    spatial_extent=spatial_extent,
    temporal_extent=temporal_extent,
    bands=bands,
    properties=properties,
)

from openeo.processes import array_element
def labeled_ndvi(x):
    b4 = array_element(x,label="red")
    b8 = array_element(x,label="nir")
    ndvi = (b8-b4)/(b8+b4)
    return ndvi

s2_ndvi = s2_datacube.reduce_dimension(dimension="band",reducer=labeled_ndvi)

s2_ndvi = s2_ndvi.execute()
```