### PR TITLE
fix: import experimental processes

### DIFF
--- a/openeo_processes_dask/process_implementations/__init__.py
+++ b/openeo_processes_dask/process_implementations/__init__.py
@@ -15,6 +15,13 @@ except ImportError as e:
         "Did not load machine learning processes due to missing dependencies: Install them like this: `pip install openeo-processes-dask[implementations, ml]`"
     )
 
+try:
+    from .experimental import *
+except ImportError as e:
+    logger.warning(
+        "Did not experimental processes due to missing dependencies: Install them like this: `pip install openeo-processes-dask[implementations, experimental]`"
+    )
+
 import rioxarray as rio  # Required for the .rio accessor on xarrays.
 
 import openeo_processes_dask.process_implementations.cubes._xr_interop


### PR DESCRIPTION
Experimental processes (currently there's only resample_cube_spatial), where not imported/included in the process registry.