### PR TITLE
[load_stac] allow load from static Collection

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/load.py
+++ b/openeo_processes_dask/process_implementations/cubes/load.py
@@ -80,11 +80,12 @@ def _search_for_parent_catalog(url):
         )
     return catalog_url, collection_id
 
+
 def _get_items_from_static_collection(url):
     stac_api = pystac_client.stac_api_io.StacApiIO()
     stac_dict = json.loads(stac_api.read_text(url))
     collection = stac_api.stac_object_from_dict(stac_dict)
-    
+
     items_list = None
     items = []
     if "items" in stac_dict:


### PR DESCRIPTION
Allow to use `load_stac` with a static STAC Collection. It will be necessary for the test suite, since we plan to host the STAC Collection on GitHub (no API).

You can test it with the one I prepared:

```python
from openeo.local import LocalConnection
local_conn = LocalConnection("./")

url = "https://raw.githubusercontent.com/clausmichele/openeo-test-suite/eurac_process_graphs/src/openeo_test_suite/data/SENTINEL2_L2A_SAMPLE/SENTINEL2_L2A_SAMPLE.json"
bands = ["B04"]

s2_cube = local_conn.load_stac(url=url,
   bands=bands,
)
s2_cube.execute()
```