### PR TITLE
Fix quantiles to be compliant with 2.0.0 and accept list inputs

### DIFF
--- a/openeo_processes_dask/process_implementations/math.py
+++ b/openeo_processes_dask/process_implementations/math.py
@@ -280,8 +280,16 @@ def quantiles(
             "The process `quantiles` only allows that either the `probabilities` or the `q` parameter is set."
         )
 
+    # Since processes 2.0.0 q was deprecated in favor of a combined probabilities parameter, cater for this
+    if isinstance(probabilities, int):
+        q = probabilities
+        probabilities = None
+
     if isinstance(probabilities, list):
         probabilities = np.array(probabilities)
+
+    if isinstance(data, list):
+        data = np.array(data)
 
     if q is not None:
         probabilities = np.arange(1.0 / q, 1, 1.0 / q)


### PR DESCRIPTION
Fix quantiles to be compliant with 2.0.0 and accept list inputs.

Found by the new test suite and want to make you aware. I won't have time to add tests, this is more a bug report rather than a full PR.