### PR TITLE
Clip correctly in linear_scale_range when inputMax < inputMin

### DIFF
--- a/openeo_processes_dask/process_implementations/math.py
+++ b/openeo_processes_dask/process_implementations/math.py
@@ -228,7 +228,10 @@ def arctan2(y, x):
 
 
 def linear_scale_range(x, inputMin, inputMax, outputMin=0.0, outputMax=1.0):
-    x = clip(x, inputMin, inputMax)
+    if inputMax < inputMin:
+        x = clip(x, inputMax, inputMin)
+    else:
+        x = clip(x, inputMin, inputMax)
     lsr = ((x - inputMin) / (inputMax - inputMin)) * (outputMax - outputMin) + outputMin
     return lsr
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -78,6 +78,16 @@ def test_normalized_difference(x, y, expected):
     assert np.array_equal(result_np, result_dask.compute(), equal_nan=True)
 
 
+def test_linear_scale_range():
+    array = np.array([5, 0])
+
+    dask_array = da.from_array(array)
+    result_dask = linear_scale_range(dask_array, inputMin=0, inputMax=5)
+    assert np.array_equal(np.array([1, 0]), result_dask.compute(), equal_nan=True)
+    result_dask = linear_scale_range(dask_array, inputMin=5, inputMax=0)
+    assert np.array_equal(np.array([0, 1]), result_dask.compute(), equal_nan=True)
+
+
 def test_clip():
     array = np.array([5, 0])
     result_np = clip(array, min=0, max=2)


### PR DESCRIPTION
Clip correctly in linear_scale_range when inputMax < inputMin

Found by the new test suite and want to make you aware. I won't have time to add tests, this is more a bug report rather than a full PR.
