### PR TITLE
dimension_labels should return a list, datetimes should be ISO formatted

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/general.py
+++ b/openeo_processes_dask/process_implementations/cubes/general.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
+import numpy as np
 import xarray as xr
+from numpy.typing import ArrayLike
 from openeo_pg_parser_networkx.pg_schema import *
 
 from openeo_processes_dask.process_implementations.data_model import RasterCube
@@ -28,12 +30,17 @@ def create_raster_cube() -> RasterCube:
     return xr.DataArray()
 
 
-def dimension_labels(data: RasterCube, dimension: str) -> RasterCube:
+def dimension_labels(data: RasterCube, dimension: str) -> ArrayLike:
     if dimension not in data.dims:
         raise DimensionNotAvailable(
             f"Provided dimension ({dimension}) not found in data.dims: {data.dims}"
         )
-    return data.coords[dimension]
+
+    coords = data.coords[dimension]
+    if np.issubdtype(coords.dtype, np.datetime64):
+        return np.datetime_as_string(coords, timezone="UTC")
+    else:
+        return np.array(data.coords[dimension])
 
 
 def add_dimension(


### PR DESCRIPTION
- dimension_labels should return a list, not a raster datacube
- datetimes should be ISO formatted

Found by the new test suite and want to make you aware. I won't have time to add tests, this is more a bug report rather than a full PR.
