### PR TITLE
Bug in mask polygon 

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/mask_polygon.py
+++ b/openeo_processes_dask/process_implementations/cubes/mask_polygon.py
@@ -88,7 +88,7 @@ def mask_polygon(
     for i, d in enumerate(data_dims):
         data_chunks[d] = chunks_shapes[i][0]
 
-    if data_dims.index(x_dim[0]) < data_dims.index(y_dim[0]):
+    if data_dims.index(x_dim) < data_dims.index(y_dim):
         final_mask = da.zeros(
             (x_dim_size, y_dim_size),
             chunks={x_dim: data_chunks[x_dim], y_dim: data_chunks[y_dim]},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openeo-processes-dask"
-version = "2024.1.1"
+version = "2024.1.2"
 description = "Python implementations of many OpenEO processes, dask-friendly by default."
 authors = ["Lukas Weidenholzer <lukas.weidenholzer@eodc.eu>", "Sean Hoyal <sean.hoyal@eodc.eu>", "Valentina Hutter <valentina.hutter@eodc.eu>"]
 maintainers = ["EODC Staff <support@eodc.eu>"]


### PR DESCRIPTION
Culprit line in mask polygon is indexing the y_dim and x_dim values, they're strings so this will fail if you the dimensions are named latitude or longitude. :smile: 