### PR TITLE
#237 aggregate_spatial needs to translate incoming geometries to same CRS as the data

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/aggregate.py
+++ b/openeo_processes_dask/process_implementations/cubes/aggregate.py
@@ -146,8 +146,9 @@ def aggregate_spatial(
             gdf = gpd.GeoDataFrame(geometry=[polygon])
             gdf.crs = DEFAULT_CRS
 
+    gdf = gdf.to_crs(data.rio.crs)
     geometries = gdf.geometry.values
-
+     
     positional_parameters = {"data": 0}
     vec_cube = data.xvec.zonal_stats(
         geometries,


### PR DESCRIPTION
If the incoming geometries have a different crs, we now "translate" this to the same CRS as the data (since the xvec function assumes same crs without checking it).

I have added the line that i *think* should fix this. Please check that its correct and does not have any side-effects that I was unaware of. 