### PR TITLE
Add basic handling for X,Y,band,time dimensions for transpose and rep…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ A subset of process implementations with heavy or unstable dependencies are hidd
 ## Development environment
 openeo-processes-dask requires poetry >1.2, see their [docs](https://python-poetry.org/docs/#installation) for installation instructions.
 
+Clone the repository with `--recurse-submodules` to also fetch the process specs:
+```
+git clone --recurse-submodules git@github.com:Open-EO/openeo-processes-dask.git
+```
+
 To setup the python venv and install this project into it run:
 ```
 poetry install --all-extras

--- a/openeo_processes_dask/process_implementations/cubes/resample.py
+++ b/openeo_processes_dask/process_implementations/cubes/resample.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional, Union
 
-import odc.geo.xr 
+import odc.geo.xr
 import rioxarray  # needs to be imported to set .rio accessor on xarray objects.
 from odc.geo.geobox import resolution_from_affine
 from pyproj.crs import CRS, CRSError
@@ -50,7 +50,7 @@ def resample_spatial(
             f'Selected resampling method "{method}" is not available! Please select one of '
             f"[{', '.join(resample_methods_list)}]"
         )
-        
+
     dims = list(data.dims)
 
     known_dims = [


### PR DESCRIPTION
Hi all,

Corresponding issue which this will cover as well: https://github.com/Open-EO/openeo-processes-dask/issues/243.

I am currently working on adding the `align` parameter to the resample_spatial function as per the OpenEO processes [documentation](https://processes.openeo.org/#resample_spatial).

Part of this also involves handling cubes with different dimensions setups. For now, I edited the original fixed transpose to check the shape in the 4 basic dimensions.

Currently I added the `align` as a dummy parameter which does not do anything but allows us to use the function.

Couple of questions and ideas:
1.  Regarding the transpose/handling of the cube dimensions, how could we go about handling other dimensions since there are a lot of possibilities? 
2. How should the align parameter be implemented? what should the result be by using different align options?
3. Since we already use ODC reprojection there is parameter `anchor` available which appears to do a similar operation to align [link to the docs](https://odc-geo.readthedocs.io/en/latest/_api/odc.geo.xr.ODCExtensionDa.reproject.html)

Any feedback, ideas and suggestions are welcome! 

Thanks!