### PR TITLE
Clarify installation with system/conda/micromamba GDAL and add warnings about GDAL dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@
 
 If you already have GDAL installed on your system (or in a conda/micromamba env), always install the matching Python bindings first, then this package:
 
+#### Installation
+
+Install this project via pip:
+
+```bash
+pip install "gdal==$(gdal-config --version)" openeo-processes-dask
+```
+
+Note that by default this only installs the JSON process specs.
+In order to install the actual implementations, add the `implementations` extra:
+
+
 ```bash
 pip install "gdal==$(gdal-config --version)" openeo-processes-dask[implementations]
 ````


### PR DESCRIPTION
This PR updates the **Installation** section of the README to clarify and expand the guidance around GDAL dependencies.

* Documented the recommended installation workflow when using system GDAL, conda, or micromamba.
* Added explicit instructions for users without GDAL installed yet.
* Included a pip-only alternative for users who prefer wheels (with a caution about potential GDAL mismatches).
* Added GDAL dependency warnings in the **Extra Build Variants** and **Development Environment** sections to make developers aware that GDAL must be preinstalled or pinned correctly.

This ensures both casual users (who only need specs) and developers (who require full implementations) have clear, reliable installation paths and are aware of the GDAL pitfalls.

@ValentinaHutter 