### PR TITLE
update numpy dependency to >=2.0

### DIFF
--- a/openeo_processes_dask/process_implementations/comparison.py
+++ b/openeo_processes_dask/process_implementations/comparison.py
@@ -26,7 +26,7 @@ __all__ = [
 
 
 def is_infinite(x: ArrayLike):
-    if np.issubsctype(get_scalar_type(x), np.number):
+    if np.issubdtype(get_scalar_type(x), np.number):
         return np.isinf(x)
     else:
         return False
@@ -56,24 +56,24 @@ def eq(
     x_dtype = get_scalar_type(x)
     y_dtype = get_scalar_type(y)
 
-    if np.issubsctype(x_dtype, np.number) and np.issubsctype(y_dtype, np.number):
+    if np.issubdtype(x_dtype, np.number) and np.issubdtype(y_dtype, np.number):
         if delta:
             ar_eq = np.isclose(x, y, atol=delta)
         else:
             ar_eq = x == y
 
-    elif np.issubsctype(x_dtype, np.bool_) and np.issubsctype(y_dtype, np.bool_):
+    elif np.issubdtype(x_dtype, np.bool_) and np.issubdtype(y_dtype, np.bool_):
         ar_eq = x == y
 
-    elif np.issubsctype(x_dtype, np.flexible) and np.issubsctype(y_dtype, np.flexible):
+    elif np.issubdtype(x_dtype, np.flexible) and np.issubdtype(y_dtype, np.flexible):
         if not case_sensitive:
-            if np.issubsctype(get_scalar_type(x), np.character):
+            if np.issubdtype(get_scalar_type(x), np.character):
                 x = np.char.lower(x)
-            if np.issubsctype(get_scalar_type(y), np.character):
+            if np.issubdtype(get_scalar_type(y), np.character):
                 y = np.char.lower(y)
         ar_eq = x == y
 
-    elif np.issubsctype(x_dtype, np.flexible) and np.issubsctype(y_dtype, np.flexible):
+    elif np.issubdtype(x_dtype, np.flexible) and np.issubdtype(y_dtype, np.flexible):
         ar_eq = x == y
     else:
         return False

--- a/openeo_processes_dask/process_implementations/utils.py
+++ b/openeo_processes_dask/process_implementations/utils.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 def get_scalar_type(obj):
     if np.isscalar(obj):
-        return np.dtype(obj).type
+        return np.dtype(type(obj))
     if hasattr(obj, "dtype"):
         return obj.dtype
     return np.object_

--- a/openeo_processes_dask/process_implementations/utils.py
+++ b/openeo_processes_dask/process_implementations/utils.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 def get_scalar_type(obj):
     if np.isscalar(obj):
-        return np.obj2sctype(type(obj))
+        return np.dtype(obj).type
     if hasattr(obj, "dtype"):
         return obj.dtype
     return np.object_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pandas = { version = ">=2.0.0", optional = true }
 xarray = { version = ">=2022.11.0,<2025.08.01", optional = true }
 dask = {extras = ["array", "dataframe", "distributed"], version = ">=2023.4.0,<2025.2.0", optional = true}
 rasterio = { version = "^1.3.4", optional = true }
-dask-geopandas = { version = "0.4.3", optional = true }
+dask-geopandas = { version = ">=0.4.3", optional = false }
 xgboost = { version = ">=1.5.1,<2.1.4", optional = true }
 rioxarray = { version = ">=0.12.0,<1", optional = true }
 openeo-pg-parser-networkx = { version = ">=2025.10", optional = true }
@@ -43,9 +43,9 @@ scipy = "^1.11.3"
 xvec = { version = "0.2.0", optional = true }
 joblib = { version = ">=1.3.2", optional = true }
 geoparquet = "^0.0.3"
-pyarrow = "^15.0.2"
+pyarrow = ">=15.0.2"
 openeo = ">=0.36.0"
-numpy = { version = "<2.0.0", optional = false }
+numpy = { version = ">=2.0.0", optional = false }
 pystac = { version = "<1.12.0", optional = false }
 zarr = "<=2.18.7"
 xcube-eopf = ">=0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ rasterio = { version = "^1.3.4", optional = true }
 dask-geopandas = { version = ">=0.4.3", optional = false }
 xgboost = { version = ">=1.5.1,<2.1.4", optional = true }
 rioxarray = { version = ">=0.12.0,<1", optional = true }
-openeo-pg-parser-networkx = { version = ">=2025.10", optional = true }
+openeo-pg-parser-networkx = { git = "https://github.com/vincentsarago/openeo-pg-parser-networkx.git", branch = "feature/update-numpy-dependency" }
 rqadeforestation = ">=0.1"
 odc-geo = { version = ">=0.4.1,<1", optional = true }
 stac_validator = { version = ">=3.3.1", optional = true }


### PR DESCRIPTION
This PR includes a specific reference to the updated parser supporting numpy 2.0 from here https://github.com/Open-EO/openeo-pg-parser-networkx/pull/113

Once that PR gets merged, installing it from git can be removed from the `pyproject.toml` file.