### PR TITLE
resample_spatial gets added method 'geocode' uses xcube_resampling

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/resample.py
+++ b/openeo_processes_dask/process_implementations/cubes/resample.py
@@ -1,11 +1,12 @@
 import logging
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 import odc.geo.xr
 import rioxarray  # needs to be imported to set .rio accessor on xarray objects.
 import xarray as xr
 from odc.geo.geobox import resolution_from_affine
+from pyproj import Transformer
 from pyproj.crs import CRS, CRSError
 
 from openeo_processes_dask.process_implementations.data_model import RasterCube
@@ -31,7 +32,83 @@ resample_methods_list = [
     "med",
     "q1",
     "q3",
+    "geocode",  # new-addition which uses xcube
 ]
+
+
+def _find_lon_lat_vars(ds: xr.Dataset) -> tuple[str, str]:
+    """
+    Return names of lon/lat variables in ds.
+    Accepts both (lon, lat) and (longitude, latitude) as coords or data_vars.
+    """
+    candidates = [
+        ("lon", "lat"),
+        ("longitude", "latitude"),
+    ]
+    for lon_name, lat_name in candidates:
+        if (lon_name in ds.coords or lon_name in ds.data_vars) and (
+            lat_name in ds.coords or lat_name in ds.data_vars
+        ):
+            return lon_name, lat_name
+    raise OpenEOException(
+        'method="geocode" requires 2D lon/lat layers present as variables or coordinates '
+        "(expected names: lon/lat or longitude/latitude)."
+    )
+
+
+def _default_interp_methods_from_dtypes(ds: xr.Dataset) -> dict[str, str]:
+    """
+    xcube supports 'nearest' and 'bilinear' (among others), and applies them per variable.
+    We default:
+      - integer/flags -> nearest
+      - float -> bilinear
+    """
+    methods: dict[str, str] = {}
+    for var_name, da in ds.data_vars.items():
+        if np.issubdtype(da.dtype, np.integer) or np.issubdtype(da.dtype, np.bool_):
+            methods[var_name] = "nearest"
+        else:
+            methods[var_name] = "bilinear"
+    return methods
+
+
+def _build_target_gm_from_lonlat_bbox(
+    lon2d: xr.DataArray,
+    lat2d: xr.DataArray,
+    target_crs: CRS,
+    resolution: float,
+    tile_size: int = 1024,
+):
+    """
+    Build a regular xcube GridMapping using the lon/lat bbox as extent.
+    If target_crs != EPSG:4326, bbox is transformed to target CRS.
+    """
+    # Lazy reductions (works with dask-backed lon/lat)
+    west = float(lon2d.min().compute())
+    east = float(lon2d.max().compute())
+    south = float(lat2d.min().compute())
+    north = float(lat2d.max().compute())
+
+    # Transform bounds from EPSG:4326 into target CRS if needed
+    src_crs = CRS.from_epsg(4326)
+    if not target_crs.equals(src_crs) and not (
+        target_crs.is_geographic and src_crs.is_geographic
+    ):
+        transformer = Transformer.from_crs(src_crs, target_crs, always_xy=True)
+        west, south, east, north = transformer.transform_bounds(
+            west, south, east, north
+        )
+
+    # Import here so the module still works even if xcube-resampling isn't installed
+    from xcube_resampling.gridmapping import GridMapping
+
+    return GridMapping.regular_from_bbox(
+        bbox=(west, south, east, north),
+        xy_res=resolution,
+        crs=target_crs,
+        tile_size=tile_size,
+        is_j_axis_up=False,
+    )
 
 
 def resample_spatial(
@@ -46,27 +123,252 @@ def resample_spatial(
     if data.openeo.y_dim is None or data.openeo.x_dim is None:
         raise DimensionMissing(f"Spatial dimension missing for dataset: {data} ")
 
-    methods_list = [
-        "near",
-        "bilinear",
-        "cubic",
-        "cubicspline",
-        "lanczos",
-        "average",
-        "mode",
-        "max",
-        "min",
-        "med",
-        "q1",
-        "q3",
-    ]
-
-    if method not in methods_list:
+    if method not in resample_methods_list:
         raise Exception(
             f'Selected resampling method "{method}" is not available! Please select one of '
-            f"[{', '.join(methods_list)}]"
+            f"[{', '.join(resample_methods_list)}]"
         )
 
+    dim_order = data.dims
+    data_cp = data.transpose(..., data.openeo.y_dim, data.openeo.x_dim)
+
+    # using xcube if method == "geocode" --> xcube-based "geocode"
+    if method == "geocode":
+        try:
+            from xcube_resampling.rectify import rectify_dataset
+            from xcube_resampling.spatial import resample_in_space
+        except Exception as e:
+            raise OpenEOException(
+                'method="geocode" requires the optional dependency "xcube-resampling" '
+                "to be installed."
+            ) from e
+
+        y_dim = data.openeo.y_dim
+        x_dim = data.openeo.x_dim
+        band_dim = getattr(data.openeo, "band_dim", None) or "bands"
+
+        def _bands_da_to_vars_ds(
+            da: xr.DataArray, band_dim_: str = "bands"
+        ) -> xr.Dataset:
+            """
+            Convert DataArray with a bands dimension into Dataset with one data_var per band label.
+            Examples:
+              da(bands,y,x) with bands=['chl_nn'] -> ds with var 'chl_nn'(y,x)
+              da(time,bands,y,x)                 -> ds with vars '...' (time,y,x)
+            """
+            # If there is no bands dim, fall back to a single-var dataset
+            if band_dim_ not in da.dims:
+                name = da.name or "data"
+                return da.to_dataset(name=name)
+
+            if band_dim_ not in da.coords:
+                raise OpenEOException(
+                    f'For method="geocode", band dimension {band_dim_!r} must have labels as a coordinate.'
+                )
+
+            labels = [str(v) for v in da[band_dim_].values.tolist()]
+
+            vars_dict = {}
+            for lbl in labels:
+                # .sel keeps all remaining dims, drops only the selected band coordinate
+                band_slice = da.sel({band_dim_: lbl}).drop_vars(
+                    band_dim_, errors="ignore"
+                )
+                vars_dict[lbl] = band_slice
+
+            # Keep all non-band coords (including time, lon/lat if present as coords)
+            coords = {k: v for k, v in da.coords.items() if k != band_dim_}
+            ds = xr.Dataset(vars_dict, coords=coords)
+
+            # Preserve attrs at dataset level for convenience
+            ds.attrs.update(getattr(da, "attrs", {}))
+            return ds
+
+        def _stack_extra_dims_for_xcube(
+            ds: xr.Dataset, vars_: list[str]
+        ) -> tuple[xr.Dataset, bool, list[str]]:
+            """
+            Ensure xcube sees at most one non-spatial dim before (y,x).
+            If vars have >1 extra dims (e.g. time,bands,y,x), stack all extra dims into '__plane__'.
+            Returns (new_ds, stacked?, extra_dims)
+            """
+            plane_dim_ = "__plane__"
+            # Determine extra dims from the first variable (assume consistent for payload)
+            v0 = vars_[0]
+            extra = [d for d in ds[v0].dims if d not in (y_dim, x_dim)]
+            stacked_ = False
+
+            # Always enforce spatial dims at the end
+            if len(extra) == 0:
+                for v in vars_:
+                    ds[v] = ds[v].transpose(y_dim, x_dim)
+                return ds, False, extra
+
+            if len(extra) == 1:
+                for v in vars_:
+                    ds[v] = ds[v].transpose(extra[0], y_dim, x_dim)
+                return ds, False, extra
+
+            # len(extra) > 1 -> stack
+            stacked_ = True
+            stacked_vars = {}
+            for v in vars_:
+                da = ds[v].transpose(*extra, y_dim, x_dim)
+                stacked_vars[v] = da.stack({plane_dim_: extra})
+            ds = ds.assign(stacked_vars)
+            return ds, stacked_, extra
+
+        def _unstack_after_xcube(
+            da: xr.DataArray, extra_dims: list[str]
+        ) -> xr.DataArray:
+            """
+            Unstack '__plane__' back to original extra dims order.
+            """
+            plane_dim_ = "__plane__"
+            if plane_dim_ in da.dims:
+                da = da.unstack(plane_dim_)
+                # Restore extra dims order explicitly (xarray may reorder)
+                da = da.transpose(*extra_dims, y_dim, x_dim)
+            return da
+
+        # build source_ds
+        is_dataarray = isinstance(data_cp, xr.DataArray)
+
+        if is_dataarray:
+            # Convert bands->vars so payload isn't hidden inside a 'bands' dimension
+            source_ds = _bands_da_to_vars_ds(data_cp, band_dim_=band_dim)
+        else:
+            source_ds = data_cp
+
+        # find lon/lat
+        lon_name, lat_name = _find_lon_lat_vars(source_ds)
+        lon2d = source_ds[lon_name]
+        lat2d = source_ds[lat_name]
+
+        if lon2d.ndim != 2 or lat2d.ndim != 2:
+            raise OpenEOException(
+                f'For method="geocode", {lon_name!r} and {lat_name!r} must be 2D arrays '
+                f"aligned to the spatial grid (got shapes {lon2d.shape} and {lat2d.shape})."
+            )
+
+        # force lon/lat to be coords (safest for GridMapping inference)
+        source_ds = source_ds.assign_coords({lon_name: lon2d, lat_name: lat2d})
+
+        # payload variables
+        payload_vars = list(source_ds.data_vars)
+
+        # remove lon/lat/spatial_ref if they are data_vars in some inputs
+        payload_vars = [
+            v for v in payload_vars if v not in (lon_name, lat_name, "spatial_ref")
+        ]
+        if not payload_vars:
+            raise OpenEOException(
+                'method="geocode": no payload variables found to rectify (only lon/lat present?).'
+            )
+
+        # Default per-variable interpolation (flags -> nearest, floats -> bilinear)
+        interp_methods = _default_interp_methods_from_dtypes(source_ds[payload_vars])
+
+        # Ensure xcube can handle dimensionality: stack if needed
+        source_payload = source_ds[payload_vars]
+        source_payload, stacked, extra_dims = _stack_extra_dims_for_xcube(
+            source_payload, payload_vars
+        )
+
+        # Decide default vs explicit target grid
+        user_passed_projection = projection is not None
+        user_passed_resolution = resolution not in (0, None)
+
+        if not user_passed_projection and not user_passed_resolution:
+            # Default xcube behavior: derive regular grid from source GM internally (to_regular)
+            out_ds = rectify_dataset(
+                source_payload,
+                interp_methods=interp_methods,
+                tile_size=1024,
+            )
+        else:
+            # Explicit grid mode: projection/resolution define the output grid
+            if projection is None:
+                target_crs = CRS.from_epsg(4326)
+            else:
+                try:
+                    target_crs = CRS.from_user_input(projection)
+                except CRSError as e:
+                    raise CRSError(
+                        f"Provided projection string: '{projection}' can not be parsed to CRS."
+                    ) from e
+
+            if not user_passed_resolution:
+                raise OpenEOException(
+                    'method="geocode": if "projection" is provided explicitly, you must also '
+                    'provide a non-zero "resolution" so an explicit target grid can be built.'
+                )
+
+            target_gm = _build_target_gm_from_lonlat_bbox(
+                lon2d=lon2d,
+                lat2d=lat2d,
+                target_crs=target_crs,
+                resolution=float(resolution),
+                tile_size=1024,
+            )
+
+            # resample_in_space will pick rectification (irregular -> regular) automatically
+            out_ds = resample_in_space(
+                source_payload,
+                target_gm=target_gm,
+                interp_methods=interp_methods,
+            )
+
+        # convert output back
+        if is_dataarray:
+            # Convert vars back into a banded DataArray, preserving time/etc.
+            out_vars = [v for v in out_ds.data_vars if v != "spatial_ref"]
+            if not out_vars:
+                raise OpenEOException(
+                    'method="geocode": rectification produced no output variables (only spatial_ref).'
+                )
+
+            out_bands = []
+            for v in out_vars:
+                da_v = out_ds[v]
+                if stacked:
+                    da_v = _unstack_after_xcube(da_v, extra_dims)
+                out_bands.append(da_v)
+
+            out = xr.concat(out_bands, dim=band_dim)
+            out = out.assign_coords({band_dim: out_vars})
+
+            rename_dims = {}
+            if "lat" in out.dims and y_dim not in out.dims:
+                rename_dims["lat"] = y_dim
+            if "lon" in out.dims and x_dim not in out.dims:
+                rename_dims["lon"] = x_dim
+            if "latitude" in out.dims and y_dim not in out.dims:
+                rename_dims["latitude"] = y_dim
+            if "longitude" in out.dims and x_dim not in out.dims:
+                rename_dims["longitude"] = x_dim
+            if rename_dims:
+                out = out.rename(rename_dims)
+
+            out = out.transpose(*dim_order, missing_dims="ignore")
+
+        else:
+            # dataset input: just unstack variables if needed and restore dim order
+            if stacked:
+                fixed = {}
+                for v in [v for v in out_ds.data_vars if v != "spatial_ref"]:
+                    fixed[v] = _unstack_after_xcube(out_ds[v], extra_dims)
+                out_ds = out_ds.assign(fixed)
+            out = out_ds.transpose(*dim_order, missing_dims="ignore")
+
+        # preserve original attrs (except CRS handled elsewhere)
+        for k, v in data.attrs.items():
+            if k.lower() != "crs":
+                out.attrs[k] = v
+
+        return out
+
+    # ORIGINAL ODC-based behavior continues from here
     # Assert resampling method is correct.
     if method == "near":
         method = "nearest"
@@ -76,10 +378,6 @@ def resample_spatial(
             f'Selected resampling method "{method}" is not available! Please select one of '
             f"[{', '.join(resample_methods_list)}]"
         )
-
-    dim_order = data.dims
-
-    data_cp = data.transpose(..., data.openeo.y_dim, data.openeo.x_dim)
 
     if projection is None:
         projection = data_cp.rio.crs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,3 +184,20 @@ def geometry_dict(west=10.47, east=10.48, south=46.12, north=46.18, crs="EPSG:43
 @pytest.fixture
 def wkt_string():
     return 'PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]'
+
+
+@pytest.fixture
+def curvilinear_raster_cube(bounding_box, temporal_interval, random_raster_data):
+    """A small dask-backed curvilinear cube with 2D lon/lat layers.
+
+    Used to test resample_spatial(method="geocode").
+    """
+    from tests.mockdata import create_fake_curvilinear_rastercube
+
+    return create_fake_curvilinear_rastercube(
+        data=random_raster_data,
+        spatial_extent=bounding_box,
+        temporal_extent=temporal_interval,
+        bands=["B02", "B03", "B04", "B08"],
+        backend="dask",
+    )

--- a/tests/mockdata.py
+++ b/tests/mockdata.py
@@ -62,3 +62,89 @@ def create_fake_rastercube(
         raster_cube.data = da.from_array(raster_cube.data, chunks=chunks)
 
     return raster_cube
+
+
+def create_fake_curvilinear_rastercube(
+    data,
+    spatial_extent: BoundingBox,
+    temporal_extent: TemporalInterval,
+    bands: list,
+    backend="numpy",
+    chunks=("auto", "auto", "auto", -1),
+    lon_name: str = "lon",
+    lat_name: str = "lat",
+    warp_strength: float = 0.02,
+):
+    """Create a fake *curvilinear* cube.
+
+    This matches what resample_spatial(method="geocode") expects:
+      - regular index dims (y, x)
+      - 2D lon/lat layers aligned to (y, x) as coords (or data vars)
+      - payload in a DataArray with optional (t, bands)
+    """
+
+    # Base 1D lon/lat axes used only to build the 2D curvilinear lon/lat.
+    len_x = max(spatial_extent.west, spatial_extent.east) - min(
+        spatial_extent.west, spatial_extent.east
+    )
+    len_y = max(spatial_extent.south, spatial_extent.north) - min(
+        spatial_extent.south, spatial_extent.north
+    )
+
+    nx = data.shape[0]
+    ny = data.shape[1]
+
+    lon_1d = np.linspace(
+        min(spatial_extent.west, spatial_extent.east),
+        max(spatial_extent.west, spatial_extent.east),
+        num=nx,
+        endpoint=False,
+    )
+    lat_1d = np.linspace(
+        min(spatial_extent.south, spatial_extent.north),
+        max(spatial_extent.south, spatial_extent.north),
+        num=ny,
+        endpoint=False,
+    )
+
+    lon2d, lat2d = np.meshgrid(lon_1d, lat_1d)
+
+    # Make it curvilinear by adding a smooth warp that depends on both i and j.
+    if len_x > 0:
+        lon2d = lon2d + (warp_strength * len_x) * np.sin(
+            2.0 * np.pi * (lat2d - lat2d.min()) / max(len_y, 1e-12)
+        )
+    if len_y > 0:
+        lat2d = lat2d + (warp_strength * len_y) * np.cos(
+            2.0 * np.pi * (lon2d - lon2d.min()) / max(len_x, 1e-12)
+        )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        t_coords = pd.date_range(
+            start=np.datetime64(temporal_extent.root[0].root),
+            end=np.datetime64(temporal_extent.root[1].root),
+            periods=data.shape[2],
+        ).values
+
+    # Use integer index coords for x/y; lon/lat are the real geo coords.
+    x_idx = np.arange(nx)
+    y_idx = np.arange(ny)
+
+    coords = {
+        "x": x_idx,
+        "y": y_idx,
+        "t": t_coords,
+        "bands": bands,
+        lon_name: (("y", "x"), lon2d.astype(np.float64)),
+        lat_name: (("y", "x"), lat2d.astype(np.float64)),
+    }
+
+    raster_cube = xr.DataArray(data=data, dims=("x", "y", "t", "bands"), coords=coords)
+
+    if "dask" in backend:
+        import dask.array as da
+
+        raster_cube.data = da.from_array(raster_cube.data, chunks=chunks)
+
+    return raster_cube

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -14,7 +14,7 @@ from openeo_processes_dask.process_implementations.cubes.resample import (
     resample_spatial,
 )
 from tests.general_checks import general_output_checks
-from tests.mockdata import create_fake_rastercube
+from tests.mockdata import create_fake_curvilinear_rastercube, create_fake_rastercube
 
 
 @pytest.mark.parametrize(
@@ -197,3 +197,67 @@ def test_aggregate_temporal_period(
         resample_cube_temporal(
             data=input_cube, target=target_cube, dimension="time", valid_within=None
         )
+
+
+@pytest.mark.parametrize("size", [(30, 30, 5, 4)])
+@pytest.mark.parametrize("dtype", [np.float32])
+def test_resample_spatial_geocode_curvilinear(
+    temporal_interval,
+    bounding_box,
+    random_raster_data,
+):
+    """Ensure method='geocode' can rectify a curvilinear grid to a regular grid."""
+    pytest.importorskip("xcube_resampling")
+
+    input_cube = create_fake_curvilinear_rastercube(
+        data=random_raster_data,
+        spatial_extent=bounding_box,
+        temporal_extent=temporal_interval,
+        bands=["B02", "B03", "B04", "B08"],
+        backend="dask",
+    )
+
+    # Default behavior: derive a regular grid internally from lon/lat.
+    output_cube = resample_spatial(data=input_cube, method="geocode")
+
+    dx = np.diff(output_cube["x"].values)
+    dy = np.diff(output_cube["y"].values)
+
+    assert output_cube.odc.spatial_dims == ("y", "x")
+    assert output_cube["x"].ndim == 1
+    assert output_cube["y"].ndim == 1
+    assert np.all(dx != 0)
+    assert np.all(dy != 0)
+    assert np.all(dx > 0) or np.all(dx < 0)
+    assert np.all(dy > 0) or np.all(dy < 0)
+
+
+@pytest.mark.parametrize("size", [(30, 30, 5, 4)])
+@pytest.mark.parametrize("dtype", [np.float32])
+def test_resample_spatial_geocode_curvilinear_explicit_grid(
+    temporal_interval,
+    bounding_box,
+    random_raster_data,
+):
+    """Ensure explicit projection + resolution path works for method='geocode'."""
+    pytest.importorskip("xcube_resampling")
+
+    input_cube = create_fake_curvilinear_rastercube(
+        data=random_raster_data,
+        spatial_extent=bounding_box,
+        temporal_extent=temporal_interval,
+        bands=["B02", "B03", "B04", "B08"],
+        backend="dask",
+    )
+
+    # Provide explicit grid params (EPSG:4326 in degrees).
+    output_cube = resample_spatial(
+        data=input_cube,
+        projection="EPSG:4326",
+        resolution=0.001,
+        method="geocode",
+    )
+
+    assert output_cube.odc.spatial_dims == ("y", "x")
+    assert output_cube["x"].ndim == 1
+    assert output_cube["y"].ndim == 1


### PR DESCRIPTION
Rest of the behaviour except method=="geocode" follows the odc implementation for resample_spatial
- method also provisions user to provide projection and resolution as arguments to be passed on to the xcube_resampling logic

Original issue: https://github.com/Open-EO/openeo-processes-dask/issues/356

also refer: https://github.com/orgs/destine-datalake-cube/projects/3/views/1?pane=issue&itemId=150801985&issue=destine-datalake-cube%7Cdedl-openeo-coordination%7C1