### PR TITLE
load_url: improve type annotation

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/load.py
+++ b/openeo_processes_dask/process_implementations/cubes/load.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import PurePosixPath
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 from urllib.parse import unquote, urlparse
 
 import numpy as np
@@ -318,7 +318,7 @@ def load_stac(
     return stack
 
 
-def load_url(url: str, format: str, options={}):
+def load_url(url: str, format: Literal["GeoJSON", "JSON", "Parquet"], options={}):
     import geopandas as gpd
     import requests
 


### PR DESCRIPTION
The function will raise an exception
unless the parameter has one of the three
specific values, so put that in the type
annotation so it's visible from
outside the function.