### PR TITLE
Stop using implicit Optional

### DIFF
--- a/openeo_processes_dask/process_implementations/arrays.py
+++ b/openeo_processes_dask/process_implementations/arrays.py
@@ -530,7 +530,7 @@ def rearrange(
     data: ArrayLike,
     order: ArrayLike,
     axis: Optional[int] = None,
-    source_transposed_axis: int = None,
+    source_transposed_axis: Optional[int] = None,
 ):
     if len(data) == 0:
         return data

--- a/openeo_processes_dask/process_implementations/cubes/_filter.py
+++ b/openeo_processes_dask/process_implementations/cubes/_filter.py
@@ -40,7 +40,7 @@ __all__ = [
 
 
 def filter_temporal(
-    data: RasterCube, extent: TemporalInterval, dimension: str = None
+    data: RasterCube, extent: TemporalInterval, dimension: Optional[str] = None
 ) -> RasterCube:
     temporal_dims = data.openeo.temporal_dims
 
@@ -130,7 +130,7 @@ def filter_labels(
     return data
 
 
-def filter_bands(data: RasterCube, bands: list[str] = None) -> RasterCube:
+def filter_bands(data: RasterCube, bands: Optional[list[str]] = None) -> RasterCube:
     if bands is None:
         raise BandFilterParameterMissing(
             "The process `filter_bands` requires the parameters `bands` to be set."

--- a/openeo_processes_dask/process_implementations/cubes/merge.py
+++ b/openeo_processes_dask/process_implementations/cubes/merge.py
@@ -54,7 +54,7 @@ def _align_coordinates(
 def merge_cubes(
     cube1: RasterCube,
     cube2: RasterCube,
-    overlap_resolver: Callable = None,
+    overlap_resolver: Optional[Callable] = None,
     context: Optional[dict] = None,
 ) -> RasterCube:
     if context is None:

--- a/openeo_processes_dask/process_implementations/ml/random_forest.py
+++ b/openeo_processes_dask/process_implementations/ml/random_forest.py
@@ -25,7 +25,7 @@ def fit_regr_random_forest(
     num_trees: int = 100,
     max_variables: Optional[Union[int, str]] = None,
     predictors_vars: Optional[list[str]] = None,
-    target_var: str = None,
+    target_var: Optional[str] = None,
     **kwargs,
 ) -> Booster:
     import xgboost as xgb
@@ -124,7 +124,7 @@ def predict_random_forest(
     data: RasterCube,
     model: Booster,
     axis: int = -1,
-    context: dict = None,
+    context: Optional[dict] = None,
 ) -> RasterCube:
     import xgboost as xgb
 

--- a/openeo_processes_dask/process_implementations/text.py
+++ b/openeo_processes_dask/process_implementations/text.py
@@ -8,7 +8,9 @@ __all__ = [
 ]
 
 
-def text_begins(data: str, pattern: str, case_sensitive: Optional[bool] = True) -> str:
+def text_begins(
+    data: str, pattern: str, case_sensitive: Optional[bool] = True
+) -> Optional[str]:
     if data:
         if case_sensitive:
             return data.startswith(pattern)
@@ -20,7 +22,7 @@ def text_begins(data: str, pattern: str, case_sensitive: Optional[bool] = True) 
 
 def text_contains(
     data: str, pattern: str, case_sensitive: Optional[bool] = True
-) -> str:
+) -> Optional[str]:
     if data:
         if case_sensitive:
             return pattern in data
@@ -30,7 +32,9 @@ def text_contains(
         return None
 
 
-def text_ends(data: str, pattern: str, case_sensitive: Optional[bool] = True) -> str:
+def text_ends(
+    data: str, pattern: str, case_sensitive: Optional[bool] = True
+) -> Optional[str]:
     if data:
         if case_sensitive:
             return data.endswith(pattern)

--- a/tests/general_checks.py
+++ b/tests/general_checks.py
@@ -1,5 +1,5 @@
 # Checks here are inspired by makepath/xarray-spatial/tests/general_checks.py
-from typing import List
+from typing import List, Optional
 
 import dask.array as da
 import numpy as np
@@ -13,7 +13,7 @@ def general_output_checks(
     expected_results=None,
     verify_crs: bool = False,
     verify_attrs: bool = False,
-    expected_dims: list = None,
+    expected_dims: Optional[list] = None,
     rtol=1e-06,
 ):
     assert isinstance(output_cube.data, type(input_cube.data))


### PR DESCRIPTION
This is prohibited since PEP-484,
so convert the implicit optionals
to explicit optionals.

Leave all other type errors in
the code to make this PR easier
to review.