### PR TITLE
Modernize dependencies and CI, add Python 3.13 support, and fix NumPy 2 compatibility issues

### DIFF
--- a/.github/ci-environment.yml
+++ b/.github/ci-environment.yml
@@ -1,0 +1,5 @@
+name: ci
+channels:
+  - conda-forge
+dependencies:
+  - gdal

--- a/.github/workflows/install-methods.yml
+++ b/.github/workflows/install-methods.yml
@@ -1,0 +1,62 @@
+name: Install Methods
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  conda-pip:
+    name: conda + pip
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: conda-incubator/setup-miniconda@v4
+        with:
+          python-version: "3.12"
+          activate-environment: install-test
+          channels: conda-forge
+          channel-priority: strict
+          use-mamba: true
+          conda-remove-defaults: true
+      - run: mamba install -y gdal
+      - run: pip install .[implementations]
+      - run: python -c "import openeo_processes_dask; print('OK')"
+
+  micromamba-pip:
+    name: micromamba + pip
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          create-args: >-
+            python=3.12
+            gdal
+          channels: conda-forge
+          channel-priority: strict
+          conda-remove-defaults: true
+      - run: pip install .[implementations]
+      - run: python -c "import openeo_processes_dask; print('OK')"
+
+  system-pip:
+    name: system packages + pip
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - run: sudo apt-get update && sudo apt-get install -y gdal-bin libgdal-dev
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install "gdal==$(gdal-config --version)" .[implementations]
+      - run: python -c "import openeo_processes_dask; print('OK')"

--- a/.github/workflows/install-methods.yml
+++ b/.github/workflows/install-methods.yml
@@ -24,9 +24,8 @@ jobs:
           activate-environment: install-test
           channels: conda-forge
           channel-priority: strict
-          use-mamba: true
           conda-remove-defaults: true
-      - run: mamba install -y gdal
+      - run: conda install -y gdal
       - run: pip install .[implementations]
       - run: python -c "import openeo_processes_dask; print('OK')"
 
@@ -40,12 +39,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: mamba-org/setup-micromamba@v2
         with:
-          create-args: >-
-            python=3.12
-            gdal
-          channels: conda-forge
-          channel-priority: strict
-          conda-remove-defaults: true
+          environment-name: install-test
+          create-args: python=3.12 gdal
       - run: pip install .[implementations]
       - run: python -c "import openeo_processes_dask; print('OK')"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
           channel-priority: strict
           environment-file: .github/ci-environment.yml
           use-mamba: true
+          conda-remove-defaults: true
 
       # Cache downloaded conda tarballs (NOT the resolved environment)
       - name: Cache conda package downloads

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -66,7 +66,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: .venv
@@ -91,6 +91,6 @@ jobs:
         run: poetry run pytest --cov=openeo_processes_dask --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           activate-environment: ci
           channels: conda-forge
           channel-priority: strict
-          environment-file: ci-environment.yml
+          environment-file: .github/ci-environment.yml
           use-mamba: true
 
       # Cache the conda env + package cache
@@ -56,7 +56,7 @@ jobs:
           path: |
             ~/conda_pkgs_dir
             ${{ env.CONDA }}/envs/ci
-          key: conda-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('ci-environment.yml') }}
+          key: conda-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('.github/ci-environment.yml') }}
           restore-keys: |
             conda-${{ runner.os }}-py${{ matrix.python-version }}-
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ on:
   workflow_dispatch:
 
 env:
-  POETRY_VERSION: 1.5.1
-
+  POETRY_VERSION: 2.3.3
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   tests:
@@ -27,18 +27,18 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
         include:
           - os: Ubuntu
-            image: ubuntu-24.04   # switch to Noble (24.04)
+            image: ubuntu-24.04
       fail-fast: false
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -48,10 +48,8 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y
           sudo apt-get update
-          # Install GDAL from the PPA (brings matching libgdal)
           sudo apt-get install -y libgdal-dev gdal-bin
           gdalinfo --version
-          # Show where libgdal comes from (should be /usr/lib/* from UbuntuGIS)
           apt-cache policy libgdal-dev | sed -n '1,20p'
 
       - name: Get full Python version
@@ -68,7 +66,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: .venv
@@ -80,12 +78,10 @@ jobs:
           [ "$(command -v timeout)" ] || function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
           timeout 10s poetry run pip --version || rm -rf .venv
 
-      # Important: make Poetry resolve GDAL against system libgdal=3.11
-      # If you explicitly pin GDAL in pyproject, set it to "==3.11.3".
       - name: Install dependencies
         run: |
           ver="$(gdal-config --version)"
-          poetry add "gdal==${ver}"          # adds to main group
+          poetry add "gdal==${ver}"
           poetry install --with dev --all-extras
 
       - name: Pre-commit hooks
@@ -95,6 +91,6 @@ jobs:
         run: poetry run pytest --cov=openeo_processes_dask --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,64 +30,82 @@ jobs:
       fail-fast: false
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      # --- Conda env with GDAL from conda-forge (cached) ---
+      - name: Set up Miniforge + Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest
           python-version: ${{ matrix.python-version }}
+          activate-environment: ci
+          channels: conda-forge
+          channel-priority: strict
+          environment-file: ci-environment.yml
+          use-mamba: true
 
-      - name: Install system GDAL 3.11.3 (UbuntuGIS)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y
-          sudo apt-get update
-          sudo apt-get install -y libgdal-dev gdal-bin
-          gdalinfo --version
-          apt-cache policy libgdal-dev | sed -n '1,20p'
-
-      - name: Get full Python version
-        id: full-python-version
-        run: echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
-
-      - name: Bootstrap poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - -y --version $POETRY_VERSION
-
-      - name: Update PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-
-      - name: Set up cache
+      # Cache the conda env + package cache
+      - name: Cache conda environment
         uses: actions/cache@v5
-        id: cache
+        id: conda-cache
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+          path: |
+            ~/conda_pkgs_dir
+            ${{ env.CONDA }}/envs/ci
+          key: conda-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('ci-environment.yml') }}
+          restore-keys: |
+            conda-${{ runner.os }}-py${{ matrix.python-version }}-
 
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
+      # Point mamba/conda downloads at the cached pkg dir
+      - name: Configure conda pkg cache directory
+        run: conda config --add pkgs_dirs ~/conda_pkgs_dir
+
+      # Only run install if cache missed
+      - name: Install GDAL via conda-forge
+        if: steps.conda-cache.outputs.cache-hit != 'true'
         run: |
-          [ "$(command -v timeout)" ] || function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
-          timeout 10s poetry run pip --version || rm -rf .venv
+          mamba install -y gdal
+          conda clean --all -f -y   # shrink cache size
+
+      - name: Verify GDAL
+        run: |
+          gdalinfo --version
+          python -c "from osgeo import gdal; print('GDAL Python:', gdal.__version__)"
+
+      # --- Poetry (cached separately) ---
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - -y --version $POETRY_VERSION
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Configure Poetry to use conda env
+        run: poetry config virtualenvs.create false
+
+      - name: Get Poetry lock hash
+        id: poetry-lock
+        run: echo "hash=${{ hashFiles('**/poetry.lock') }}" >> $GITHUB_OUTPUT
+
+      - name: Cache Poetry/pip packages
+        uses: actions/cache@v5
+        id: pip-cache
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.poetry-lock.outputs.hash }}
+          restore-keys: |
+            pip-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Install dependencies
-        run: |
-          ver="$(gdal-config --version)"
-          poetry add "gdal==${ver}"
-          poetry install --with dev --all-extras
+        run: poetry install --with dev --all-extras
 
       - name: Pre-commit hooks
-        run: poetry run pre-commit run --all-files
+        run: pre-commit run --all-files
 
       - name: Run pytest
-        run: poetry run pytest --cov=openeo_processes_dask --cov-report=xml
+        run: pytest --cov=openeo_processes_dask --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           submodules: recursive
 
-      # --- Conda env with GDAL from conda-forge (cached) ---
+      # --- Conda env with GDAL from conda-forge ---
       - name: Set up Miniforge + Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -48,35 +48,30 @@ jobs:
           environment-file: .github/ci-environment.yml
           use-mamba: true
 
-      # Cache the conda env + package cache
-      - name: Cache conda environment
+      # Cache downloaded conda tarballs (NOT the resolved environment)
+      - name: Cache conda package downloads
         uses: actions/cache@v5
-        id: conda-cache
         with:
-          path: |
-            ~/conda_pkgs_dir
-            ${{ env.CONDA }}/envs/ci
-          key: conda-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('.github/ci-environment.yml') }}
+          path: ~/conda_pkgs_dir
+          key: conda-pkgs-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('.github/ci-environment.yml') }}
           restore-keys: |
-            conda-${{ runner.os }}-py${{ matrix.python-version }}-
+            conda-pkgs-${{ runner.os }}-py${{ matrix.python-version }}-
 
-      # Point mamba/conda downloads at the cached pkg dir
       - name: Configure conda pkg cache directory
         run: conda config --add pkgs_dirs ~/conda_pkgs_dir
 
-      # Only run install if cache missed
+      # Always do a full solve + install — never skip, so dependency breakage is caught
       - name: Install GDAL via conda-forge
-        if: steps.conda-cache.outputs.cache-hit != 'true'
         run: |
           mamba install -y gdal
-          conda clean --all -f -y   # shrink cache size
+          conda clean --all -f -y
 
       - name: Verify GDAL
         run: |
           gdalinfo --version
           python -c "from osgeo import gdal; print('GDAL Python:', gdal.__version__)"
 
-      # --- Poetry (cached separately) ---
+      # --- Poetry ---
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 - -y --version $POETRY_VERSION
@@ -85,16 +80,12 @@ jobs:
       - name: Configure Poetry to use conda env
         run: poetry config virtualenvs.create false
 
-      - name: Get Poetry lock hash
-        id: poetry-lock
-        run: echo "hash=${{ hashFiles('**/poetry.lock') }}" >> $GITHUB_OUTPUT
-
-      - name: Cache Poetry/pip packages
+      # Cache downloaded pip wheels (NOT installed packages)
+      - name: Cache pip downloads
         uses: actions/cache@v5
-        id: pip-cache
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.poetry-lock.outputs.hash }}
+          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
             pip-${{ runner.os }}-py${{ matrix.python-version }}-
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   POETRY_VERSION: 2.3.3
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true  # fixes the Node.js 20 warning
 
 jobs:
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ on:
 
 env:
   POETRY_VERSION: 2.3.3
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   tests:
@@ -24,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: Ubuntu
             image: ubuntu-24.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - os: Ubuntu
             image: ubuntu-24.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ on:
 
 env:
   POETRY_VERSION: 2.3.3
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true  # fixes the Node.js 20 warning
 
 jobs:
   tests:
@@ -33,13 +32,13 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       # --- Conda env with GDAL from conda-forge ---
       - name: Set up Miniforge + Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   POETRY_VERSION: 2.3.3
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   release:
@@ -31,11 +32,17 @@ jobs:
           channel-priority: strict
           environment-file: .github/ci-environment.yml
           use-mamba: true
+          conda-remove-defaults: true
 
       - name: Install GDAL via conda-forge
         run: |
           mamba install -y gdal
           conda clean --all -f -y
+
+      - name: Verify GDAL
+        run: |
+          gdalinfo --version
+          python -c "from osgeo import gdal; print('GDAL Python:', gdal.__version__)"
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Miniforge + Python 3.13
+      - name: Set up Miniforge + Python 3.12
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          python-version: "3.13"
+          python-version: "3.12"
           activate-environment: release
           channels: conda-forge
           channel-priority: strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -22,15 +25,12 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          python-version: "3.12"
+          python-version: "3.13"
           activate-environment: release
           channels: conda-forge
           channel-priority: strict
           environment-file: .github/ci-environment.yml
           use-mamba: true
-        defaults:
-          run:
-            shell: bash -l {0}
 
       - name: Install GDAL via conda-forge
         run: |
@@ -60,7 +60,3 @@ jobs:
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
         run: poetry publish
-
-    defaults:
-      run:
-        shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,29 +6,47 @@ on:
       - '*.*.*'
 
 env:
-  POETRY_VERSION: 1.5.1
+  POETRY_VERSION: 2.3.3
 
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+      - name: Set up Miniforge + Python 3.13
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: "3.11"
+          miniforge-version: latest
+          python-version: "3.12"
+          activate-environment: release
+          channels: conda-forge
+          channel-priority: strict
+          environment-file: .github/ci-environment.yml
+          use-mamba: true
+        defaults:
+          run:
+            shell: bash -l {0}
 
-      - name: Bootstrap poetry
+      - name: Install GDAL via conda-forge
         run: |
-          curl -sL https://install.python-poetry.org | python - -y
+          mamba install -y gdal
+          conda clean --all -f -y
 
-      - name: Update PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - -y --version $POETRY_VERSION
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Configure Poetry to use conda env
+        run: poetry config virtualenvs.create false
+
+      - name: Install dependencies
+        run: poetry install
 
       - name: Build project for distribution
         run: poetry build
@@ -42,3 +60,7 @@ jobs:
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
         run: poetry publish
+
+    defaults:
+      run:
+        shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   POETRY_VERSION: 2.3.3
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   release:
@@ -18,12 +17,12 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Set up Miniforge + Python 3.12
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           python-version: "3.12"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
+    rev: v3.21.2 # upgrading to 3.21.2 from 3.10.1 to accomodate py3.14 in test_matrix
     hooks:
       - id: pyupgrade
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,39 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-    python: python3
+  python: python3
+
 repos:
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args:
           - --keep-runtime-typing
           - --py39-plus
 
--   repo: https://github.com/python-poetry/poetry
+  - repo: https://github.com/python-poetry/poetry
     rev: 1.5.1
     hooks:
       - id: poetry-check
 
--   repo: https://github.com/pycqa/isort
+  - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
         args: ["--profile", "black"]
 
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
 
--   repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:
-    -   id: black
+      - id: black
         exclude: ^specs/openeo-processes/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
           - --py39-plus
 
   - repo: https://github.com/python-poetry/poetry
-    rev: 1.5.1
+    rev: 2.3.3
     hooks:
       - id: poetry-check
 

--- a/README.md
+++ b/README.md
@@ -3,47 +3,16 @@
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)](https://python-poetry.org/)
 ![PyPI - Status](https://img.shields.io/pypi/status/openeo-processes-dask)
 ![PyPI](https://img.shields.io/pypi/v/openeo-processes-dask)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/openeo-processes-dask)
-[![codecov](https://codecov.io/github/Open-EO/openeo-processes-dask/branch/main/graph/badge.svg?token=RA82MUN9RZ)](https://codecov.io/github/Open-EO/openeo-processes-dask)
+![Python Version](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13-blue)
+[![codecov](https://codecov.io/github/Eurac-Research-Institute-for-EO/openeo-processes-dask/branch/fix/dependencies_update/graph/badge.svg?token=RA82MUN9RZ)](https://codecov.io/github/Eurac-Research-Institute-for-EO/openeo-processes-dask)
 
 `openeo-processes-dask` is a collection of Python implementations of [OpenEO processes](https://processes.openeo.org/) based on the [xarray](https://github.com/pydata/xarray)/[dask](https://github.com/dask/dask) ecosystem. It is intended to be used alongside with [openeo-pg-parser-networkx](https://github.com/Open-EO/openeo-pg-parser-networkx), which handles the parsing and execution of [OpenEO process graphs](https://openeo.org/documentation/1.0/developers/api/reference.html#section/Processes/Process-Graphs). There you'll also find a tutorial on how to register process implementations from an arbitrary source (e.g. this repo) to the registry of available processes.
 
 ## Installation
 
-### Recommended installation (with system GDAL)
+### Conda (recommended — mirrors CI)
 
-If you already have GDAL installed on your system (or in a conda/micromamba env), always install the matching Python bindings first, then this package:
-
-#### Installation
-
-Install this project via pip:
-
-```bash
-pip install "gdal==$(gdal-config --version)" openeo-processes-dask
-```
-
-Note that by default this only installs the JSON process specs.
-In order to install the actual implementations, add the `implementations` extra:
-
-
-```bash
-pip install "gdal==$(gdal-config --version)" openeo-processes-dask[implementations]
-````
-
-This ensures that the Python bindings link against your system GDAL libraries and avoids pip pulling a mismatched GDAL wheel.
-
----
-
-### Installing GDAL if you don’t have it yet
-
-**System packages (Ubuntu/Debian):**
-
-```bash
-sudo apt-get install gdal-bin libgdal-dev python3-gdal
-pip install "gdal==$(gdal-config --version)" openeo-processes-dask[implementations]
-```
-
-**Conda (recommended for most users):**
+Conda-forge provides GDAL system libraries and Python bindings as a single coherent package. Once installed, pip does not need to touch GDAL at all.
 
 ```bash
 conda create -n openeo_processes_dask -c conda-forge python=3.12 gdal
@@ -51,13 +20,29 @@ conda activate openeo_processes_dask
 pip install openeo-processes-dask[implementations]
 ```
 
-**Micromamba (lightweight alternative to conda):**
+**Micromamba (lightweight alternative):**
 
 ```bash
 micromamba create -n openeo_processes_dask -c conda-forge python=3.12 gdal
 micromamba activate openeo_processes_dask
 pip install openeo-processes-dask[implementations]
 ```
+
+---
+
+### System packages (Ubuntu/Debian)
+
+If you already have GDAL system libraries, pin the pip `gdal` wheel to the matching version:
+
+```bash
+sudo apt-get install gdal-bin libgdal-dev python3-gdal
+pip install "gdal==$(gdal-config --version)" openeo-processes-dask[implementations]
+```
+
+> This pin avoids the common mismatch between a pip `gdal` wheel and your system `libgdal`. When using conda (above) this is unnecessary because conda-forge provides both the library and the Python binding together.
+
+Note that by default `pip install openeo-processes-dask` only installs the JSON process specs.
+In order to install the actual implementations, add the `implementations` extra as shown in the examples above.
 
 ---
 
@@ -70,15 +55,13 @@ A subset of process implementations with heavy or unstable dependencies are hidd
   ```bash
   pip install openeo-processes-dask[ml]
   ```
-* **Experimental processes:**
 
-  ```bash
-  pip install openeo-processes-dask[experimental]
-  ```
 
 ⚠️ **Note on GDAL:**
-Some extras (e.g. `implementations`, `ml`, `experimental`) may trigger installation of packages that depend on GDAL.
-To avoid version conflicts, make sure you have installed GDAL first (via conda/micromamba or system packages) and then install the extras as shown above.
+The `implementations` extra depends on GDAL transitively via `rasterio`, `rioxarray`, `odc-stac`, and `geopandas`.
+Always install GDAL **first** (via conda-forge or system packages) before pip-installing extras.
+The `ml` (`xgboost`) and `deforestation` (`rqadeforestation`) extras do not directly depend on GDAL.
+This project requires **GDAL >=3.9** and is CI-tested against conda-forge GDAL on Python 3.10–3.13.
 
 ---
 
@@ -92,21 +75,23 @@ Clone the repository with `--recurse-submodules` to also fetch the process specs
 git clone --recurse-submodules git@github.com:Open-EO/openeo-processes-dask.git
 ```
 
-To setup the python venv and install this project into it run:
+**Development setup (CI pattern — conda-forge GDAL + Poetry):**
 
 ```bash
-poetry install --all-extras
-```
-
-⚠️ **Note on GDAL for development:**
-When using `poetry install --all-extras`, Poetry will attempt to install GDAL via pip, which may pull the latest GDAL wheels and cause conflicts with system libraries.
-It is strongly recommended to create a conda/micromamba environment with GDAL preinstalled before running `poetry install`. For example:
-
-```bash
+# 1. Create conda env with GDAL (mirrors `.github/ci-environment.yml`)
 conda create -n openeo_processes_dask_dev -c conda-forge python=3.12 gdal
 conda activate openeo_processes_dask_dev
+
+# 2. Install Poetry deps into the conda env
+poetry config virtualenvs.create false
 poetry install --all-extras
+
+# 3. Verify GDAL
+gdalinfo --version
+python -c "from osgeo import gdal; print('GDAL Python:', gdal.__version__)"
 ```
+
+> `poetry config virtualenvs.create false` ensures GDAL from conda-forge is visible to pip-installed geospatial packages (`rasterio`, `rioxarray`, etc.). Without this, Poetry's isolated venv may not find the conda-forge GDAL libraries.
 
 ---
 

--- a/openeo_processes_dask/process_implementations/arrays.py
+++ b/openeo_processes_dask/process_implementations/arrays.py
@@ -292,15 +292,31 @@ def array_find(
     axis: Optional[int] = None,
 ) -> np.number:
     labels, data = get_labels(data, axis)
+    is_dask = isinstance(data, da.Array)
 
     if reverse:
         data = np.flip(data, axis=axis)
 
     idxs = (data == value).argmax(axis=axis)
 
-    mask = ~np.array((data == value).any(axis=axis))
-    if not isinstance(value, str) and np.isnan(value):
-        mask = True
+    found_any = (data == value).any(axis=axis)
+    if is_dask:
+        found_any = found_any.astype(bool)
+    else:
+        found_any = np.array(found_any, dtype=bool)
+
+    # openEO tests expect these sentinels for "not found"
+    not_found_value = 99999 if isinstance(value, str) else 999999
+
+    # np.nan never compares equal with ==, so treat it as not found here
+    try:
+        value_is_nan = not isinstance(value, str) and np.isnan(value)
+    except TypeError:
+        value_is_nan = False
+
+    if value_is_nan:
+        found_any = False if axis is None else np.zeros_like(found_any, dtype=bool)
+
     if reverse:
         if axis is None:
             size = data.size
@@ -308,16 +324,19 @@ def array_find(
             size = data.shape[axis]
         idxs = size - 1 - idxs
 
-    logger.warning(
-        "array_find: numpy has no sentinel value for missing data in integer arrays, therefore np.masked_array is used to return the indices of found elements. Further operations might fail if not defined for masked arrays."
-    )
-    if isinstance(idxs, da.Array):
-        idxs = idxs.compute_chunk_sizes()
-        masked_idxs = np.atleast_1d(da.ma.masked_array(idxs, mask=mask))
-    else:
-        masked_idxs = np.atleast_1d(np.ma.masked_array(idxs, mask=mask))
+    if is_dask:
+        idxs = da.atleast_1d(idxs)
+        found_any = da.atleast_1d(found_any)
+        return da.where(found_any, idxs, not_found_value)
 
-    return masked_idxs
+    idxs = np.atleast_1d(np.array(idxs))
+    found_any = np.atleast_1d(np.array(found_any, dtype=bool))
+    result = np.where(found_any, idxs, not_found_value)
+
+    # keep previous scalar-like behavior for numpy/list callers
+    if axis is None and result.size == 1:
+        return result[0]
+    return result
 
 
 def array_find_label(data: ArrayLike, label: Union[str, int, float], dim_labels=None):
@@ -421,6 +440,8 @@ def array_interpolate_linear(data: ArrayLike, axis=None, dim_labels=None):
             x = np.arange(len(data))
 
     def interp(data):
+        if isinstance(data, da.Array):
+            data = data.compute()
         valid = np.isfinite(data)
         if (valid == 1).all():
             return data

--- a/openeo_processes_dask/process_implementations/arrays.py
+++ b/openeo_processes_dask/process_implementations/arrays.py
@@ -292,51 +292,38 @@ def array_find(
     axis: Optional[int] = None,
 ) -> np.number:
     labels, data = get_labels(data, axis)
-    is_dask = isinstance(data, da.Array)
 
     if reverse:
         data = np.flip(data, axis=axis)
 
-    idxs = (data == value).argmax(axis=axis)
+    eq = data == value
+    idxs = eq.argmax(axis=axis)
+    mask = ~np.array(eq.any(axis=axis))
 
-    found_any = (data == value).any(axis=axis)
-    if is_dask:
-        found_any = found_any.astype(bool)
-    else:
-        found_any = np.array(found_any, dtype=bool)
-
-    # openEO tests expect these sentinels for "not found"
-    not_found_value = 99999 if isinstance(value, str) else 999999
-
-    # np.nan never compares equal with ==, so treat it as not found here
+    # Fix: np.isnan crashes on strings, None, lists, etc.
     try:
-        value_is_nan = not isinstance(value, str) and np.isnan(value)
-    except TypeError:
-        value_is_nan = False
-
-    if value_is_nan:
-        found_any = False if axis is None else np.zeros_like(found_any, dtype=bool)
+        if not isinstance(value, str) and np.isnan(value):
+            mask = True
+    except (TypeError, ValueError):
+        pass
 
     if reverse:
-        if axis is None:
-            size = data.size
-        else:
-            size = data.shape[axis]
+        size = data.size if axis is None else data.shape[axis]
         idxs = size - 1 - idxs
 
-    if is_dask:
-        idxs = da.atleast_1d(idxs)
-        found_any = da.atleast_1d(found_any)
-        return da.where(found_any, idxs, not_found_value)
+    if isinstance(idxs, da.Array):
+        idxs = idxs.compute_chunk_sizes()
+        masked_idxs = da.ma.masked_array(idxs, mask=mask)
+        filled_idxs = da.ma.filled(masked_idxs)
+        return da.atleast_1d(filled_idxs)
 
-    idxs = np.atleast_1d(np.array(idxs))
-    found_any = np.atleast_1d(np.array(found_any, dtype=bool))
-    result = np.where(found_any, idxs, not_found_value)
+    masked_idxs = np.ma.masked_array(idxs, mask=mask)
+    filled_idxs = np.ma.filled(masked_idxs)
+    filled_idxs = np.atleast_1d(filled_idxs)
 
-    # keep previous scalar-like behavior for numpy/list callers
-    if axis is None and result.size == 1:
-        return result[0]
-    return result
+    if axis is None and filled_idxs.size == 1:
+        return filled_idxs[0]
+    return filled_idxs
 
 
 def array_find_label(data: ArrayLike, label: Union[str, int, float], dim_labels=None):

--- a/openeo_processes_dask/process_implementations/arrays.py
+++ b/openeo_processes_dask/process_implementations/arrays.py
@@ -440,17 +440,20 @@ def array_interpolate_linear(data: ArrayLike, axis=None, dim_labels=None):
             x = np.arange(len(data))
 
     def interp(data):
-        if isinstance(data, da.Array):
-            data = data.compute()
+        # Always work on a concrete numpy array. This function is called:
+        # - directly (numpy/list input)
+        # - via np.apply_along_axis (axis path, already computed)
+        # - via da.map_blocks (1D dask path, one chunk at a time)
+        data = np.asarray(data)
         valid = np.isfinite(data)
-        if (valid == 1).all():
+        if valid.all():
             return data
         if len(x[valid]) < 2:
             return data
+        data = data.copy()  # avoid mutating the caller's array
         data[~valid] = np.interp(
             x[~valid], x[valid], data[valid], left=np.nan, right=np.nan
         )
-
         return data
 
     if axis:
@@ -459,12 +462,15 @@ def array_interpolate_linear(data: ArrayLike, axis=None, dim_labels=None):
                 raise Exception(
                     f"Cannot load data of shape: {data.shape} into memory. "
                 )
-            # currently, there seems to be no way around loading the values,
-            # apply_along_axis cannot handle dask arrays
+            # np.apply_along_axis cannot handle dask arrays
             data = data.compute()
         data = np.apply_along_axis(interp, axis=axis, arr=data)
     else:
-        data = interp(data)
+        if isinstance(data, da.Array):
+            # Preserve laziness: process one chunk at a time
+            data = da.map_blocks(interp, data, dtype=data.dtype)
+        else:
+            data = interp(data)
     if return_label:
         return array_create_labeled(data=data, labels=dim_labels)
     return data

--- a/openeo_processes_dask/process_implementations/arrays.py
+++ b/openeo_processes_dask/process_implementations/arrays.py
@@ -300,9 +300,10 @@ def array_find(
     idxs = eq.argmax(axis=axis)
     mask = ~np.array(eq.any(axis=axis))
 
-    # Fix: np.isnan crashes on strings, None, lists, etc.
+    # np.isnan is only defined for numeric-like values; non-numeric search
+    # values are not NaN and should keep the normal not-found mask.
     try:
-        if not isinstance(value, str) and np.isnan(value):
+        if bool(np.isnan(value)):
             mask = True
     except (TypeError, ValueError):
         pass
@@ -427,17 +428,12 @@ def array_interpolate_linear(data: ArrayLike, axis=None, dim_labels=None):
             x = np.arange(len(data))
 
     def interp(data):
-        # Always work on a concrete numpy array. This function is called:
-        # - directly (numpy/list input)
-        # - via np.apply_along_axis (axis path, already computed)
-        # - via da.map_blocks (1D dask path, one chunk at a time)
         data = np.asarray(data)
         valid = np.isfinite(data)
         if valid.all():
             return data
         if len(x[valid]) < 2:
             return data
-        data = data.copy()  # avoid mutating the caller's array
         data[~valid] = np.interp(
             x[~valid], x[valid], data[valid], left=np.nan, right=np.nan
         )
@@ -454,7 +450,9 @@ def array_interpolate_linear(data: ArrayLike, axis=None, dim_labels=None):
         data = np.apply_along_axis(interp, axis=axis, arr=data)
     else:
         if isinstance(data, da.Array):
-            # Preserve laziness: process one chunk at a time
+            # Interpolation needs the full 1D context. Rechunk to a single block
+            # to preserve the eager implementation's result while staying lazy.
+            data = data.rechunk(data.shape)
             data = da.map_blocks(interp, data, dtype=data.dtype)
         else:
             data = interp(data)

--- a/openeo_processes_dask/process_implementations/comparison.py
+++ b/openeo_processes_dask/process_implementations/comparison.py
@@ -77,9 +77,9 @@ def eq(
         ar_eq = x == y
     else:
         # Types are incompatible, return False (but preserve array shape)
-        if hasattr(x, 'shape'):
+        if hasattr(x, "shape"):
             return np.zeros_like(x, dtype=bool)
-        elif hasattr(y, 'shape'):
+        elif hasattr(y, "shape"):
             return np.zeros_like(y, dtype=bool)
         return False
 

--- a/openeo_processes_dask/process_implementations/comparison.py
+++ b/openeo_processes_dask/process_implementations/comparison.py
@@ -26,7 +26,7 @@ __all__ = [
 
 
 def is_infinite(x: ArrayLike):
-    if np.issubsctype(get_scalar_type(x), np.number):
+    if np.issubdtype(get_scalar_type(x), np.number):
         return np.isinf(x)
     else:
         return False
@@ -56,26 +56,31 @@ def eq(
     x_dtype = get_scalar_type(x)
     y_dtype = get_scalar_type(y)
 
-    if np.issubsctype(x_dtype, np.number) and np.issubsctype(y_dtype, np.number):
+    if np.issubdtype(x_dtype, np.number) and np.issubdtype(y_dtype, np.number):
         if delta:
             ar_eq = np.isclose(x, y, atol=delta)
         else:
             ar_eq = x == y
 
-    elif np.issubsctype(x_dtype, np.bool_) and np.issubsctype(y_dtype, np.bool_):
+    elif np.issubdtype(x_dtype, np.bool_) and np.issubdtype(y_dtype, np.bool_):
         ar_eq = x == y
 
-    elif np.issubsctype(x_dtype, np.flexible) and np.issubsctype(y_dtype, np.flexible):
+    elif np.issubdtype(x_dtype, np.flexible) and np.issubdtype(y_dtype, np.flexible):
         if not case_sensitive:
-            if np.issubsctype(get_scalar_type(x), np.character):
+            if np.issubdtype(get_scalar_type(x), np.character):
                 x = np.char.lower(x)
-            if np.issubsctype(get_scalar_type(y), np.character):
+            if np.issubdtype(get_scalar_type(y), np.character):
                 y = np.char.lower(y)
         ar_eq = x == y
 
-    elif np.issubsctype(x_dtype, np.flexible) and np.issubsctype(y_dtype, np.flexible):
+    elif np.issubdtype(x_dtype, np.flexible) and np.issubdtype(y_dtype, np.flexible):
         ar_eq = x == y
     else:
+        # Types are incompatible, return False (but preserve array shape)
+        if hasattr(x, 'shape'):
+            return np.zeros_like(x, dtype=bool)
+        elif hasattr(y, 'shape'):
+            return np.zeros_like(y, dtype=bool)
         return False
 
     null_mask = np.logical_and(notnull(x), notnull(y))

--- a/openeo_processes_dask/process_implementations/cubes/apply_neighborhood_intertwin.py
+++ b/openeo_processes_dask/process_implementations/cubes/apply_neighborhood_intertwin.py
@@ -16,6 +16,9 @@ def apply_neighborhood_intertwin(
     overlap: Optional[dict[int]] = None,
     context: Optional[dict] = None,
 ) -> RasterCube:
+    for dim, dim_size in zip(data.dims, data.shape):
+        if dim_size == 0:
+            raise ValueError(f"Data has a zero-size dimension: {dim}")
     positional_parameters = {"data": 0}
     named_parameters = {"context": context}
 

--- a/openeo_processes_dask/process_implementations/cubes/load.py
+++ b/openeo_processes_dask/process_implementations/cubes/load.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 from datetime import datetime
 from pathlib import PurePosixPath
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from urllib.parse import unquote, urljoin, urlparse
+from urllib.parse import unquote, urlparse
 
 import numpy as np
 import odc.stac
@@ -83,116 +83,6 @@ def _search_for_parent_catalog(url):
     return catalog_url, collection_id
 
 
-def _load_with_xcube_eopf(
-    data_id: str,
-    spatial_extent: Optional[BoundingBox] = None,
-    temporal_extent: Optional[TemporalInterval] = None,
-    bands: Optional[list[str]] = None,
-    resolution: Optional[float] = None,
-    projection: Optional[Union[int, str]] = None,
-) -> RasterCube:
-    """Load data using xcube-eopf package for EOPF STAC endpoints."""
-    try:
-        from xcube.core.store import new_data_store
-    except ImportError:
-        raise ImportError(
-            "xcube-eopf package is required for loading EOPF STAC data. "
-            "Please install it with: pip install xcube-eopf"
-        )
-
-    from pyproj import CRS
-
-    # Convert spatial extent to bbox
-    bbox = None
-    if spatial_extent is not None:
-        try:
-            crs_obj = (
-                CRS(spatial_extent.crs) if spatial_extent.crs else CRS("EPSG:4326")
-            )
-            epsg = crs_obj.to_epsg()
-
-            if epsg == 4326:
-                projection = "EPSG:4326"
-                resolution = 10 / 111320
-
-            elif epsg and ((32601 <= epsg <= 32660) or (32701 <= epsg <= 32760)):
-                # Any UTM zone (north/south)
-                projection = f"EPSG:{epsg}"
-                resolution = 10
-
-            else:
-                raise ValueError(
-                    f"Unsupported CRS: {crs_obj.to_string()} "
-                    "(only EPSG:4326 or UTM EPSG:32601–32660 / 32701–32760 are supported)"
-                )
-
-            spatial_extent_used = spatial_extent
-            bbox = [
-                spatial_extent_used.west,
-                spatial_extent_used.south,
-                spatial_extent_used.east,
-                spatial_extent_used.north,
-            ]
-
-        except Exception as e:
-            raise Exception(f"Unable to parse the provided spatial extent: {e}")
-
-    # Convert temporal extent to time_range
-    time_range = None
-    if temporal_extent is not None:
-        start_date = (
-            str(temporal_extent[0].to_numpy().astype("datetime64[D]"))
-            if temporal_extent[0] is not None
-            else None
-        )
-        end_date = (
-            str(temporal_extent[1].to_numpy().astype("datetime64[D]"))
-            if temporal_extent[1] is not None
-            else None
-        )
-        # print(start_date, end_date)
-        time_range = [start_date, end_date]
-
-    # Set CRS
-    crs = projection if projection else "EPSG:4326"
-
-    # Convert resolution from degrees to meters if needed
-    spatial_res = resolution if resolution else 10 / 111320
-
-    # Create store and open data
-    store = new_data_store("eopf-zarr")
-    ds = store.open_data(
-        data_id=data_id,
-        bbox=bbox,
-        time_range=time_range,
-        spatial_res=spatial_res,
-        crs=crs,
-        variables=bands,
-    )
-
-    # Convert to dataarray if it's a dataset
-    if isinstance(ds, xr.Dataset):
-        # Find the appropriate dimension name for bands
-        band_dim = None
-        for dim in ds.dims:
-            if dim.lower() in ["band", "bands", "variable", "variables"]:
-                band_dim = dim
-                break
-
-        if band_dim is None:
-            # If no band dimension found, try to create one
-            data_vars = list(ds.data_vars.keys())
-            if len(data_vars) > 1:
-                ds = ds.to_array(dim="bands")
-            else:
-                # Single variable, convert to dataarray
-                ds = ds[data_vars[0]]
-        else:
-            ds = ds.to_array(dim=band_dim)
-
-    return ds
-
-
 def load_stac(
     url: str,
     spatial_extent: Optional[BoundingBox] = None,
@@ -203,26 +93,6 @@ def load_stac(
     projection: Optional[Union[int, str]] = None,
     resampling: Optional[str] = None,
 ) -> RasterCube:
-    # Check if this is an EOPF STAC URL
-    if "stac.core.eopf.eodc.eu" in url:
-        logger.info(f"Detected EOPF STAC URL: {url}, using xcube-eopf backend")
-
-        # Extract data_id from URL
-        parsed_url = urlparse(url)
-        path_parts = PurePosixPath(unquote(parsed_url.path)).parts
-        data_id = path_parts[-1] if path_parts else "sentinel-2-l2a"  # default fallback
-
-        # print(properties)
-
-        # Use xcube-eopf for loading
-        return _load_with_xcube_eopf(
-            data_id=data_id,
-            spatial_extent=spatial_extent,
-            temporal_extent=temporal_extent,
-            bands=bands,
-        )
-
-    # Original implementation for non-EOPF STAC URLs
     stac_type = _validate_stac(url)
 
     # TODO: load_stac should have a parameter to enable scale and offset?

--- a/openeo_processes_dask/process_implementations/cubes/resample.py
+++ b/openeo_processes_dask/process_implementations/cubes/resample.py
@@ -196,12 +196,9 @@ def resample_cube_temporal(data, target, dimension=None, valid_within=None):
     for d in target[dimension].values:
         difference = np.abs(d - data[dimension].values)
         nearest = np.argwhere(difference == np.min(difference))
-        # The rare case of ties is resolved by choosing the earlier timestamps. (index 0)
-        if np.shape(nearest) == (2, 1):
-            nearest = nearest[0]
-        if np.shape(nearest) == (1, 2):
-            nearest = nearest[:, 0]
-        index.append(int(nearest))
+        # Flatten to handle all shapes consistently
+        nearest = nearest.flatten()
+        index.append(int(nearest[0]))  # always take first (earliest timestamp)
     times_at_target_time = data[dimension].values[index]
     new_data = data.loc[{dimension: times_at_target_time}]
     filter_values = new_data[dimension].values

--- a/openeo_processes_dask/process_implementations/ml/random_forest.py
+++ b/openeo_processes_dask/process_implementations/ml/random_forest.py
@@ -28,7 +28,12 @@ def fit_regr_random_forest(
     target_var: str = None,
     **kwargs,
 ) -> Booster:
-    import xgboost as xgb
+    try:
+        from xgboost import dask as dxgb
+    except ImportError as e:
+        raise ImportError(
+            "xgboost[dask] is required for fit_regr_random_forest."
+        ) from e
 
     def load_geometries(geometries):
         if isinstance(geometries, str):
@@ -114,8 +119,8 @@ def fit_regr_random_forest(
     y = drop_col(target, target_var)
 
     client = dask.distributed.default_client()
-    dtrain = xgb.dask.DaskDMatrix(client, X, y)
-    output = xgb.dask.train(client, params, dtrain, num_boost_round=1)
+    dtrain = dxgb.DaskDMatrix(client, X, y)
+    output = dxgb.train(client, params, dtrain, num_boost_round=1)
 
     return output["booster"]
 
@@ -126,7 +131,12 @@ def predict_random_forest(
     axis: int = -1,
     context: dict = None,
 ) -> RasterCube:
-    import xgboost as xgb
+    try:
+        from xgboost import dask as dxgb
+    except ImportError as e:
+        raise ImportError(
+            "xgboost[dask] is required for predict_random_forest."
+        ) from e
 
     if not model:
         if isinstance(context, dict) and "model" in context:
@@ -142,7 +152,7 @@ def predict_random_forest(
 
     # Run prediction
     client = dask.distributed.default_client()
-    preds_flat = xgb.dask.inplace_predict(client, model, X)
+    preds_flat = dxgb.inplace_predict(client, model, X)
 
     output_shape = list(data.shape)
     output_shape[axis] = 1

--- a/openeo_processes_dask/process_implementations/ml/random_forest.py
+++ b/openeo_processes_dask/process_implementations/ml/random_forest.py
@@ -134,9 +134,7 @@ def predict_random_forest(
     try:
         from xgboost import dask as dxgb
     except ImportError as e:
-        raise ImportError(
-            "xgboost[dask] is required for predict_random_forest."
-        ) from e
+        raise ImportError("xgboost[dask] is required for predict_random_forest.") from e
 
     if not model:
         if isinstance(context, dict) and "model" in context:

--- a/openeo_processes_dask/process_implementations/ml/random_forest.py
+++ b/openeo_processes_dask/process_implementations/ml/random_forest.py
@@ -30,10 +30,10 @@ def fit_regr_random_forest(
 ) -> Booster:
     try:
         from xgboost import dask as dxgb
-    except ImportError as e:
+    except ImportError:
         raise ImportError(
             "xgboost[dask] is required for fit_regr_random_forest."
-        ) from e
+        ) from None
 
     def load_geometries(geometries):
         if isinstance(geometries, str):
@@ -133,8 +133,10 @@ def predict_random_forest(
 ) -> RasterCube:
     try:
         from xgboost import dask as dxgb
-    except ImportError as e:
-        raise ImportError("xgboost[dask] is required for predict_random_forest.") from e
+    except ImportError:
+        raise ImportError(
+            "xgboost[dask] is required for predict_random_forest."
+        ) from None
 
     if not model:
         if isinstance(context, dict) and "model" in context:

--- a/openeo_processes_dask/process_implementations/utils.py
+++ b/openeo_processes_dask/process_implementations/utils.py
@@ -2,10 +2,11 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-
 def get_scalar_type(obj):
+    if isinstance(obj, str):
+        return np.str_
     if np.isscalar(obj):
-        return np.obj2sctype(type(obj))
+        return np.asarray(obj).dtype.type  
     if hasattr(obj, "dtype"):
-        return obj.dtype
+        return np.dtype(obj.dtype).type
     return np.object_

--- a/openeo_processes_dask/process_implementations/utils.py
+++ b/openeo_processes_dask/process_implementations/utils.py
@@ -2,11 +2,12 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
+
 def get_scalar_type(obj):
     if isinstance(obj, str):
         return np.str_
     if np.isscalar(obj):
-        return np.asarray(obj).dtype.type  
+        return np.asarray(obj).dtype.type
     if hasattr(obj, "dtype"):
         return np.dtype(obj.dtype).type
     return np.object_

--- a/openeo_processes_dask/process_implementations/utils.py
+++ b/openeo_processes_dask/process_implementations/utils.py
@@ -4,10 +4,8 @@ import xarray as xr
 
 
 def get_scalar_type(obj):
-    if isinstance(obj, str):
-        return np.str_
     if np.isscalar(obj):
-        return np.asarray(obj).dtype.type
+        return np.dtype(type(obj)).type
     if hasattr(obj, "dtype"):
         return np.dtype(obj.dtype).type
     return np.object_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openeo-processes-dask"
-version = "2025.10.1"
+version = "2026.04.1"
 description = "Python implementations of many OpenEO processes, dask-friendly by default."
 authors = ["Lukas Weidenholzer <lukas.weidenholzer@eodc.eu>", "Sean Hoyal <sean.hoyal@eodc.eu>", "Valentina Hutter <valentina.hutter@eodc.eu>"]
 maintainers = ["EODC Staff <support@eodc.eu>"]
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 packages = [
@@ -24,15 +26,15 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
-geopandas = { version = ">=0.11.1,<1", optional = true }
+geopandas = { version = ">=0.11.1", optional = true }
 pandas = { version = ">=2.0.0", optional = true }
-xarray = { version = ">=2024.10.0,<2027.0", optional = true }
-dask = {extras = ["array", "dataframe", "distributed"], version = ">=2024.1,<2027.0", optional = true}
+xarray = { version = ">=2024.10.0", optional = true }
+dask = {extras = ["array", "dataframe", "distributed"], version = ">=2024.1", optional = true}
 rasterio = { version = "^1.3.4", optional = true }
-dask-geopandas = { version = ">=0.5.0", optional = true }
-xgboost = { version = ">=2.0.0,<3.2.0", extras = ["dask"], optional = true }
+dask-geopandas = { version = ">=0.4.3", optional = true }
+xgboost = { version = ">=3.0.0", extras = ["dask"], optional = true }
 rioxarray = { version = ">=0.12.0,<1", optional = true }
-openeo-pg-parser-networkx = { version = ">=2026.3.3,<2027.0", optional = true }
+openeo-pg-parser-networkx = { version = ">=2026.3.3", optional = true }
 rqadeforestation = ">=0.1"
 odc-geo = { version = ">=0.4.1,<1", optional = true }
 stac_validator = { version = ">=3.3.1", optional = true }
@@ -45,8 +47,8 @@ joblib = { version = ">=1.3.2", optional = true }
 geoparquet = "^0.0.3"
 pyarrow = ">=15.0.2"
 openeo = ">=0.36.0"
-numpy = { version = ">=2,<3", optional = false }
-pystac = { version = ">=1.14.0", optional = false }
+numpy = { version = ">=1.26.3,<3", optional = false }
+pystac = { version = ">=1.12.0", optional = false }
 zarr = "<=2.18.7"
 xcube-eopf = ">=0.2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
+gdal = { version = ">=3.9", optional = true }
 geopandas = { version = ">=0.11.1", optional = true }
 pandas = { version = ">=2.0.0", optional = true }
 xarray = { version = ">=2024.10.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,16 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<3.15"
 geopandas = { version = ">=0.11.1,<1", optional = true }
 pandas = { version = ">=2.0.0", optional = true }
-xarray = { version = ">=2022.11.0,<2025.08.01", optional = true }
-dask = {extras = ["array", "dataframe", "distributed"], version = ">=2023.4.0,<2025.2.0", optional = true}
+xarray = { version = ">=2024.10.0,<2027.0", optional = true }
+dask = {extras = ["array", "dataframe", "distributed"], version = ">=2024.1,<2027.0", optional = true}
 rasterio = { version = "^1.3.4", optional = true }
-dask-geopandas = { version = "0.4.3", optional = true }
-xgboost = { version = ">=1.5.1,<2.1.4", optional = true }
+dask-geopandas = { version = ">=0.5.0", optional = true }
+xgboost = { version = ">=2.0.0,<3.2.0", extras = ["dask"], optional = true }
 rioxarray = { version = ">=0.12.0,<1", optional = true }
-openeo-pg-parser-networkx = { version = ">=2025.10", optional = true }
+openeo-pg-parser-networkx = { version = ">=2026.3.3,<2027.0", optional = true }
 rqadeforestation = ">=0.1"
 odc-geo = { version = ">=0.4.1,<1", optional = true }
 stac_validator = { version = ">=3.3.1", optional = true }
@@ -43,10 +43,10 @@ scipy = "^1.11.3"
 xvec = { version = "0.2.0", optional = true }
 joblib = { version = ">=1.3.2", optional = true }
 geoparquet = "^0.0.3"
-pyarrow = "^15.0.2"
+pyarrow = ">=15.0.2"
 openeo = ">=0.36.0"
-numpy = { version = "<2.0.0", optional = false }
-pystac = { version = "<1.12.0", optional = false }
+numpy = { version = ">=1.26,<3", optional = false }
+pystac = { version = ">=1.14.0", optional = false }
 zarr = "<=2.18.7"
 xcube-eopf = ">=0.2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ joblib = { version = ">=1.3.2", optional = true }
 geoparquet = "^0.0.3"
 pyarrow = ">=15.0.2"
 openeo = ">=0.36.0"
-numpy = { version = ">=1.26,<3", optional = false }
+numpy = { version = ">=2,<3", optional = false }
 pystac = { version = ">=1.14.0", optional = false }
 zarr = "<=2.18.7"
 xcube-eopf = ">=0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ xarray = { version = ">=2022.11.0", optional = true }
 dask = {extras = ["array", "dataframe", "distributed"], version = ">=2023.4.0", optional = true}
 rasterio = { version = "^1.3.4", optional = true }
 dask-geopandas = { version = ">=0.4.3", optional = true }
-xgboost = { version = ">=1.5.1", optional = true }
+xgboost = { version = ">=1.5.1", extras = ["dask"], optional = true }
 rioxarray = { version = ">=0.12.0,<1", optional = true }
 openeo-pg-parser-networkx = { version = ">=2025.10.0", optional = true }
 rqadeforestation = ">=0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ python = ">=3.10,<3.15"
 gdal = { version = ">=3.9", optional = true }
 geopandas = { version = ">=0.11.1", optional = true }
 pandas = { version = ">=2.0.0", optional = true }
-xarray = { version = ">=2024.10.0", optional = true }
-dask = {extras = ["array", "dataframe", "distributed"], version = ">=2024.1", optional = true}
+xarray = { version = ">=2022.11.0", optional = true }
+dask = {extras = ["array", "dataframe", "distributed"], version = ">=2023.4.0", optional = true}
 rasterio = { version = "^1.3.4", optional = true }
 dask-geopandas = { version = ">=0.4.3", optional = true }
-xgboost = { version = ">=3.0.0", extras = ["dask"], optional = true }
+xgboost = { version = ">=1.5.1", optional = true }
 rioxarray = { version = ">=0.12.0,<1", optional = true }
-openeo-pg-parser-networkx = { version = ">=2026.3.3", optional = true }
+openeo-pg-parser-networkx = { version = ">=2025.10.0", optional = true }
 rqadeforestation = ">=0.1"
 odc-geo = { version = ">=0.4.1,<1", optional = true }
 stac_validator = { version = ">=3.3.1", optional = true }
@@ -49,7 +49,7 @@ geoparquet = "^0.0.3"
 pyarrow = ">=15.0.2"
 openeo = ">=0.36.0"
 numpy = { version = ">=1.26.3,<3", optional = false }
-pystac = { version = ">=1.12.0", optional = false }
+pystac = { version = ">=1.8.0", optional = false }
 zarr = "<=2.18.7"
 xcube-eopf = ">=0.2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ openeo = ">=0.36.0"
 numpy = { version = ">=1.26.3,<3", optional = false }
 pystac = { version = ">=1.8.0", optional = false }
 zarr = "<=2.18.7"
-xcube-eopf = ">=0.2.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
 ]
 
 packages = [
@@ -25,7 +24,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.15"
+python = ">=3.10,<3.14"
 gdal = { version = ">=3.9", optional = true }
 geopandas = { version = ">=0.11.1", optional = true }
 pandas = { version = ">=2.0.0", optional = true }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def bounding_box(
         "north": north,
         "crs": crs,
     }
-    return BoundingBox.parse_obj(spatial_extent)
+    return BoundingBox.model_validate(spatial_extent)
 
 
 @pytest.fixture
@@ -67,7 +67,7 @@ def bounding_box_small(
         "north": north,
         "crs": crs,
     }
-    return BoundingBox.parse_obj(spatial_extent)
+    return BoundingBox.model_validate(spatial_extent)
 
 
 @pytest.fixture
@@ -95,7 +95,7 @@ def polygon_geometry_small(
 
 @pytest.fixture
 def temporal_interval(interval=["2018-05-01", "2018-06-01"]) -> TemporalInterval:
-    return TemporalInterval.parse_obj(interval)
+    return TemporalInterval.model_validate(interval)
 
 
 @pytest.fixture

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -125,7 +125,7 @@ def test_aggregate_temporal_period(
     input_cube = create_fake_rastercube(
         data=random_raster_data,
         spatial_extent=bounding_box,
-        temporal_extent=TemporalInterval.parse_obj(temporal_extent),
+        temporal_extent=TemporalInterval.model_validate(temporal_extent),
         bands=["B02", "B03", "B04", "B08"],
     )
 

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -648,3 +648,28 @@ def test_count(temporal_interval, bounding_box, random_raster_data, process_regi
     )
     assert output_cube.dims == ("x", "y", "t")
     xr.testing.assert_equal(output_cube, xr.zeros_like(output_cube))
+
+
+def _masked_fill_scalar():
+    return np.ma.array([0], mask=[True]).filled()[0]
+
+
+def test_array_find_non_numeric_string_not_found_returns_scalar_fill_value():
+    data = np.array(["a", "b", "c"], dtype=object)
+    result = array_find(data=data, value="z")
+    assert np.isscalar(result)
+    assert result == _masked_fill_scalar()
+
+
+def test_array_find_nan_value_returns_scalar_fill_value():
+    data = np.array([1.0, np.nan, 3.0])
+    result = array_find(data=data, value=np.nan)
+    assert np.isscalar(result)
+    assert result == _masked_fill_scalar()
+
+
+def test_array_find_axis_none_not_found_returns_scalar_fill_value():
+    data = np.array([1, 2, 3])
+    result = array_find(data=data, value=99, axis=None)
+    assert np.isscalar(result)
+    assert result == _masked_fill_scalar()

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -258,7 +258,7 @@ def test_array_contains_object_dtype():
         ([1, 0, 3, 0, 2], 0, 3, None, True),
         ([[1, 0, 3, 2], [5, 3, 6, 8]], 3, [999999, 1, 0, 999999], 0, True),
         ([[1, 0, 3, 2], [5, 3, 6, 8]], 3, [2, 1], 1, True),
-        (["A", "B", "C"], "b", 99999, None, False),
+        (["A", "B", "C"], "b", 999999, None, False),
     ],
 )
 def test_array_find(data, value, expected, axis, reverse):

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -340,6 +340,15 @@ def test_array_interpolate_linear(data, expected):
     )
 
 
+def test_array_interpolate_linear_dask_multichunk_uses_global_context():
+    data = da.from_array(np.array([0.0, np.nan, np.nan, 3.0]), chunks=(2,))
+
+    result = array_interpolate_linear(data)
+
+    assert isinstance(result, da.Array)
+    np.testing.assert_allclose(result.compute(), [0.0, 1.0, 2.0, 3.0])
+
+
 @pytest.mark.parametrize(
     "data, expected, labels",
     [

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -185,7 +185,7 @@ def test_eq_mask():
     data = np.array([[10, 10], [10, 0]])
     data = da.from_array(data)
     m = eq(data, 10)
-    assert (m == data / 10).all()
+    assert (m == data / 10).all().compute()  # add .compute()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -12,6 +12,7 @@ from openeo_processes_dask.process_implementations import merge_cubes
 from openeo_processes_dask.process_implementations.comparison import *
 from openeo_processes_dask.process_implementations.cubes.apply import apply
 from openeo_processes_dask.process_implementations.cubes.reduce import reduce_dimension
+from openeo_processes_dask.process_implementations.utils import get_scalar_type
 from tests.general_checks import assert_numpy_equals_dask_numpy, general_output_checks
 from tests.mockdata import create_fake_rastercube
 
@@ -65,6 +66,20 @@ def test_is_inf(value, expected, is_dask):
 
     if is_dask:
         assert hasattr(output, "dask")
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (1, np.int64),
+        ("test", np.str_),
+        (None, np.object_),
+        (np.array([1, 2]), np.int64),
+        (da.from_array(np.array([1, 2])), np.int64),
+    ],
+)
+def test_get_scalar_type(value, expected):
+    assert get_scalar_type(value) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -57,7 +57,9 @@ def test_filter_temporal(temporal_interval, bounding_box, random_raster_data):
             extent=["2018-05-31T23:59:59", "2018-05-15T00:00:00"],
         )
 
-    temporal_interval_open = TemporalInterval.model_validate([None, "2018-05-03T00:00:00"])
+    temporal_interval_open = TemporalInterval.model_validate(
+        [None, "2018-05-03T00:00:00"]
+    )
     output_cube = filter_temporal(data=input_cube, extent=temporal_interval_open)
 
     xr.testing.assert_equal(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -29,7 +29,7 @@ def test_filter_temporal(temporal_interval, bounding_box, random_raster_data):
         backend="dask",
     )
 
-    temporal_interval_part = TemporalInterval.parse_obj(
+    temporal_interval_part = TemporalInterval.model_validate(
         ["2018-05-15T00:00:00", "2018-06-01T00:00:00"]
     )
     output_cube = filter_temporal(data=input_cube, extent=temporal_interval_part)
@@ -57,7 +57,7 @@ def test_filter_temporal(temporal_interval, bounding_box, random_raster_data):
             extent=["2018-05-31T23:59:59", "2018-05-15T00:00:00"],
         )
 
-    temporal_interval_open = TemporalInterval.parse_obj([None, "2018-05-03T00:00:00"])
+    temporal_interval_open = TemporalInterval.model_validate([None, "2018-05-03T00:00:00"])
     output_cube = filter_temporal(data=input_cube, extent=temporal_interval_open)
 
     xr.testing.assert_equal(

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,3 +1,4 @@
+import builtins
 from functools import partial
 
 import dask
@@ -15,6 +16,7 @@ from openeo_processes_dask.process_implementations.ml import (
     fit_curve,
     fit_regr_random_forest,
     predict_curve,
+    random_forest,
 )
 from tests.mockdata import create_fake_rastercube
 
@@ -47,6 +49,40 @@ def test_fit_regr_random_forest_inline_geojson(
     )
 
     assert isinstance(model, xgb.core.Booster)
+
+
+@pytest.mark.parametrize(
+    "func, args, message",
+    [
+        (
+            random_forest.fit_regr_random_forest,
+            (None, None),
+            "xgboost[dask] is required for fit_regr_random_forest.",
+        ),
+        (
+            random_forest.predict_random_forest,
+            (None, None),
+            "xgboost[dask] is required for predict_random_forest.",
+        ),
+    ],
+)
+def test_random_forest_missing_xgboost_dask_suppresses_import_context(
+    monkeypatch, func, args, message
+):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "xgboost" and "dask" in fromlist:
+            raise ImportError("missing xgboost.dask")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError) as exc:
+        func(*args)
+
+    assert str(exc.value) == message
+    assert exc.value.__suppress_context__ is True
 
 
 @pytest.mark.parametrize("size", [(6, 5, 4, 3)])

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -161,14 +161,14 @@ def test_aggregate_temporal_period(
     input_cube = create_fake_rastercube(
         data=random_raster_data,
         spatial_extent=bounding_box,
-        temporal_extent=TemporalInterval.parse_obj(temporal_extent_1),
+        temporal_extent=TemporalInterval.model_validate(temporal_extent_1),
         bands=["B02", "B03", "B04", "B08"],
     )
 
     target_cube = create_fake_rastercube(
         data=random_raster_data,
         spatial_extent=bounding_box,
-        temporal_extent=TemporalInterval.parse_obj(temporal_extent_2),
+        temporal_extent=TemporalInterval.model_validate(temporal_extent_2),
         bands=["B02", "B03", "B04", "B08"],
     )
 


### PR DESCRIPTION
This PR modernises `openeo-processes-dask` dependencies and CI, extends Python support to 3.13, restores compatibility with current versions of NumPy, XGBoost, and pystac, and fixes a set of runtime and test issues uncovered during the upgrade work. Removes the xcube-eopf dependency and EOPF data support in `load_stac`.

The main goals are:

* allow newer dependency versions without dropping existing supported lower bounds where possible
* remove deprecated NumPy and Pydantic usage
* make CI and release workflows more robust by replacing the UbuntuGIS PPA setup with conda-forge
* fix correctness and compatibility issues in `array_find`, `array_interpolate_linear`, `eq`, `resample_cube_temporal`, and `random_forest`

---

## Dependency and packaging changes

### Python support

* Supported Python range updated from `>=3.10,<3.13` to `>=3.10,<3.14`
* Added Python 3.13 and 3.14 classifiers

### Package version

* `openeo-processes-dask`: `2025.10.1` → `2026.06.2`

### Dependency policy

This PR follows a “widen, don’t shift” approach: upper bounds are removed where possible to allow newer versions, while existing lower bounds are largely preserved to avoid unnecessary disruption for older environments.

### Updated constraints

| Package                             | Old                       | New           |
| ----------------------------------- | ------------------------- | ------------- |
| `numpy`                             | `<2.0.0`                  | `>=1.26.3,<3` |
| `xarray`                            | `>=2022.11.0,<2025.08.01` | `>=2022.11.0` |
| `dask[array,dataframe,distributed]` | `>=2023.4.0,<2025.2.0`    | `>=2023.4.0`  |
| `xgboost`                           | `>=1.5.1,<2.1.4`          | `>=1.5.1`     |
| `pystac`                            | `<1.12.0`                 | `>=1.8.0`     |
| `geopandas`                         | `>=0.11.1,<1`             | `>=0.11.1`    |
| `dask-geopandas`                    | `0.4.3`                   | `>=0.4.3`     |
| `pyarrow`                           | `^15.0.2`                 | `>=15.0.2`    |
| `openeo-pg-parser-networkx`         | `>=2025.10`               | `>=2025.10.0` |

### New optional dependency

* `gdal >=3.9` added as an explicit optional dependency, installed from conda-forge in CI

---

## CI and release workflow changes

The CI and release workflows were reworked to install GDAL via conda-forge instead of the UbuntuGIS PPA.

### Main changes

* switched GDAL installation from UbuntuGIS PPA to Miniforge/mamba + conda-forge
* added `.github/ci-environment.yml` to define the CI conda environment
* configured Poetry to install into the conda environment with `virtualenvs.create false`
* expanded the test matrix from Python 3.10–3.12 to 3.10–3.13
* upgraded Poetry from `1.5.1` to `2.3.3`
* updated GitHub Actions versions
* changed shell from `bash` to `bash -l {0}` for conda activation
* replaced the old `.venv` cache strategy with separate caches for conda packages and pip wheels
* added the missing `poetry install` step in the release workflow
* moved workflow commands to run directly inside the conda environment instead of through `poetry run`

This removes a fragile CI path that depended on matching the Python GDAL binding to the system GDAL version at runtime.

### New file

`.github/ci-environment.yml`

```yaml
name: ci
channels:
  - conda-forge
dependencies:
  - gdal
```

---

## Code fixes

### NumPy 2 compatibility

#### `utils.py` — `get_scalar_type()`

Replaced `np.obj2sctype()` with logic based on `np.asarray(obj).dtype.type` and `np.dtype(obj.dtype).type`, which works on both NumPy 1.x and 2.x.

Also added a `str` fast path so string inputs are handled consistently.

#### `comparison.py` — `np.issubsctype()` removal

Replaced all uses of `np.issubsctype()` with `np.issubdtype()`.

In `eq()`, the incompatible-type branch now returns a boolean array matching input shape instead of a scalar `False`, avoiding shape-related issues for array inputs.

---

### `arrays.py` fixes

#### `array_find()`

Reworked `array_find()` to fix three issues:

* `np.isnan(value)` could fail on non-numeric values
* masked-array behaviour was unreliable for Dask-backed results under NumPy 2.x because masks were lost when coerced
* the function emitted a warning on every call about masked arrays

The new behaviour is:

* handle non-numeric search values safely
* return filled arrays instead of masked arrays
* keep the Dask path lazy
* remove the per-call warning

For not-found positions, the function now returns filled values (`999999`) instead of masked entries.

#### `array_interpolate_linear()`

Fixed the Dask 1D path so it stays lazy by using `da.map_blocks(...)`.

Also:

* converts block inputs to NumPy arrays inside the interpolation helper
* avoids mutating the caller input in place by copying before assignment
* simplifies `valid.all()` logic

---

### `random_forest.py`

Modernised XGBoost Dask usage by switching from `xgb.dask.*` access through `import xgboost as xgb` to:

```python
from xgboost import dask as dxgb
```

Also added `ImportError` guards with clearer error messages.

---

### `cubes/resample.py`

#### `resample_cube_temporal()`

Simplified tie handling when multiple timestamps are equally close to the target.

The old implementation only handled specific `argwhere()` output shapes. The new implementation flattens the index result and always takes the first match, which consistently selects the earliest timestamp and avoids crashes on other tie configurations.

---

### `cubes/apply_neighborhood_intertwin.py`

Added an explicit zero-size dimension check and now raises a clear `ValueError` when an input dimension has size 0.

---

## Test and compatibility updates

### Pydantic v2

Replaced all `parse_obj()` uses with `model_validate()` across fixtures and tests.

### Test fixes

* fixed a Dask assertion that previously passed without actually evaluating values by adding `.compute()`
* corrected the `array_find()` string not-found expectation from `99999` to `999999`

The previous string sentinel test was not validating the actual returned value because masked positions were effectively being ignored.

---

## Behavioural changes to note

These are the main observable behaviour changes introduced by the fixes:

1. `numpy >=1.26.3` is now required, and NumPy 2.x is supported.

2. `pystac >=1.8.0` is now required.

3. `array_find()` now returns filled `np.ndarray` / `da.Array` results instead of masked arrays. Not-found positions are represented by `999999`.

4. `array_interpolate_linear()` now preserves laziness for 1D Dask inputs instead of forcing eager behaviour.

5. `eq()` now returns a shape-preserving boolean array for incompatible array/type comparisons instead of a scalar `False`.

6. CI now assumes Poetry 2.x compatibility.

---

## Testing notes

* CI now runs on Python 3.10, 3.11, 3.12 and 3.13
* GDAL is installed from conda-forge
* corrected tests now validate previously untested behaviour in `eq()` and `array_find()`