### PR TITLE
Pin GDAL to 3.13.0 for CI; keep library dep open-ended (>=3.8.4)

### DIFF
--- a/.github/ci-environment.yml
+++ b/.github/ci-environment.yml
@@ -2,4 +2,4 @@ name: ci
 channels:
   - conda-forge
 dependencies:
-  - gdal
+  - gdal=3.13.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
             pip-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Install dependencies
-        run: poetry install --with dev --all-extras
+        run: poetry install --with dev,ci --all-extras
 
       - name: Pre-commit hooks
         run: pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ pip install openeo-processes-dask[implementations]
 
 ### System packages (Ubuntu/Debian)
 
-If you already have GDAL system libraries, pin the pip `gdal` wheel to the matching version:
+If you already have GDAL system libraries, pin the pip `gdal` wheel to the matching version.
+Ubuntu 24.04 ships GDAL **3.8.4** — the minimum version required for system-level installation:
 
 ```bash
 sudo apt-get install gdal-bin libgdal-dev python3-gdal
@@ -61,7 +62,9 @@ A subset of process implementations with heavy or unstable dependencies are hidd
 The `implementations` extra depends on GDAL transitively via `rasterio`, `rioxarray`, `odc-stac`, and `geopandas`.
 Always install GDAL **first** (via conda-forge or system packages) before pip-installing extras.
 The `ml` (`xgboost`) and `deforestation` (`rqadeforestation`) extras do not directly depend on GDAL.
-This project requires **GDAL >=3.9** and is CI-tested against conda-forge GDAL on Python 3.10–3.13.
+This project requires **GDAL >=3.8.4** (the version shipped by Ubuntu 24.04) and is CI-tested against conda-forge GDAL on Python 3.10–3.13.
+
+**Version-ceiling policy:** Library dependencies in `pyproject.toml` declare only minimum versions (`>=X`). Any upper bounds (`<Y`) needed for CI go into `[tool.poetry.group.ci.dependencies]` (or the conda `ci-environment.yml` pin) so downstream consumers are never blocked. Install the `civersions` extra if your environment also needs the ceiling.
 
 ---
 
@@ -84,7 +87,7 @@ conda activate openeo_processes_dask_dev
 
 # 2. Install Poetry deps into the conda env
 poetry config virtualenvs.create false
-poetry install --all-extras
+poetry install --with dev,ci --all-extras
 
 # 3. Verify GDAL
 gdalinfo --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
-gdal = { version = ">=3.9", optional = true }
+gdal = { version = ">=3.8.4", optional = true }
 geopandas = { version = ">=0.11.1", optional = true }
 pandas = { version = ">=2.0.0", optional = true }
 xarray = { version = ">=2022.11.0", optional = true }
@@ -52,6 +52,11 @@ pystac = { version = ">=1.8.0", optional = false }
 zarr = "<=2.18.7"
 
 
+[tool.poetry.group.ci.dependencies]
+# CI-only version ceilings: protect CI from upstream breakage without
+# imposing ceilings on downstream consumers. See README for policy.
+gdal = { version = "<3.13.1" }
+
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"
 ipykernel = "^6.15.1"
@@ -63,7 +68,8 @@ pytest-cov = "^4.0.0"
 
 
 [tool.poetry.extras]
-implementations = ["geopandas", "xarray", "dask", "rasterio", "dask-geopandas", "rioxarray", "openeo-pg-parser-networkx", "odc-geo", "odc-stac", "planetary_computer", "pystac_client", "stac_validator", "xvec", "joblib"]
+civersions = ["gdal"]
+implementations = ["gdal", "geopandas", "xarray", "dask", "rasterio", "dask-geopandas", "rioxarray", "openeo-pg-parser-networkx", "odc-geo", "odc-stac", "planetary_computer", "pystac_client", "stac_validator", "xvec", "joblib"]
 ml = ["xgboost"]
 deforestation = ["rqadeforestation"]
 


### PR DESCRIPTION
Pinning the ceiling version for gdal in the pyproject.toml and also the ci