### PR TITLE
CI: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 10


### PR DESCRIPTION
This adds configuration for getting
automatic pull requests for version
updates for GitHub actions.

Updating CI actions rarely breaks,
so group all updates into a single
pull request. Also use a 10 day
cooldown to give some time for
people to discover and withdraw
any releases made by bad actors.

https://docs.github.com/en/code-security/dependabot