### PR TITLE
CI: use OIDC login for CodeCov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
   tests:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.image }}
+    permissions:
+      id-token: write # Required for CodeCov OIDC login.
     strategy:
       matrix:
         os: [Ubuntu]
@@ -103,3 +105,6 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ./coverage.xml
+          disable_search: true
+          fail_ci_if_error: false
+          use_oidc: true


### PR DESCRIPTION
CodeCov requires some kind of login
for protected branches, so enable
the OIDC login so the comparison
point isn't stuck 40+ commits
behind the latest main.

Also avoid failing the CI if
CodeCov fails since there is
a fair bit of downtime for that
service.