### PR TITLE
gitmodules: use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openeo_processes_dask/specs/openeo-processes"]
     path = openeo_processes_dask/specs/openeo-processes
-    url = git@github.com:eodcgmbh/openeo-processes.git
+    url = https://github.com/eodcgmbh/openeo-processes.git


### PR DESCRIPTION
The SSH URL requires
an authenticated SSH key,
so it fails in containers
and other similar environments.
Switch to using https instead.

Refs #383