### PR TITLE
aggregate: fix deprecation warnings

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/aggregate.py
+++ b/openeo_processes_dask/process_implementations/cubes/aggregate.py
@@ -231,12 +231,12 @@ def aggregate_temporal_period(
         applicable_temporal_dimension = temporal_dims[0]
 
     periods_to_frequency = {
-        "hour": "H",
+        "hour": "h",
         "day": "D",
         "week": "W",
-        "month": "M",
+        "month": "ME",
         "season": "QS-DEC",
-        "year": "AS",
+        "year": "YS",
     }
 
     if period in periods_to_frequency.keys():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 python = ">=3.10,<3.14"
 gdal = { version = ">=3.8.4", optional = true }
 geopandas = { version = ">=0.11.1", optional = true }
-pandas = { version = ">=2.0.0", optional = true }
+pandas = { version = ">=2.2.0", optional = true }
 xarray = { version = ">=2022.11.0", optional = true }
 dask = {extras = ["array", "dataframe", "distributed"], version = ">=2023.4.0", optional = true}
 rasterio = { version = "^1.3.4", optional = true }


### PR DESCRIPTION
Require pandas 2.2 (from January 2024)
and switch the frequency letters to
the new ones.