### PR TITLE
CI: limit concurrency on workflows

### DIFF
--- a/.github/workflows/install-methods.yml
+++ b/.github/workflows/install-methods.yml
@@ -9,6 +9,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   conda-pip:
     name: conda + pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ on:
 env:
   POETRY_VERSION: 2.3.3
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
 env:
   POETRY_VERSION: 2.3.3
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Cancel any running CI jobs for
the previous iteration of
a pull request, but always
let the CI jobs for the main
branch run to completion.

The number of concurrent CI jobs
is limited for the organization,
so this ensures this repository
doesn't gobble up all the CI
runners when someone is repeatedly
updating their pull request.