### PR TITLE
Zarr v3 support

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/load.py
+++ b/openeo_processes_dask/process_implementations/cubes/load.py
@@ -12,6 +12,7 @@ import numpy as np
 import odc.stac
 import planetary_computer as pc
 import pyproj
+import pystac
 import pystac_client
 import xarray as xr
 from openeo_pg_parser_networkx.pg_schema import BoundingBox, TemporalInterval
@@ -82,6 +83,19 @@ def _search_for_parent_catalog(url):
             "It was not possible to find the root STAC Catalog starting from the provided Collection."
         )
     return catalog_url, collection_id
+
+
+def _zarr_open_kwargs(asset: pystac.Asset, use_xarray_open_kwargs: bool) -> dict:
+    kwargs = (
+        dict(asset.extra_fields.get("xarray:open_kwargs", {}))
+        if use_xarray_open_kwargs
+        else {}
+    )
+    kwargs.setdefault("engine", "zarr")
+    kwargs.setdefault("chunks", {})
+    if "zarr_version" in kwargs and "zarr_format" not in kwargs:
+        kwargs["zarr_format"] = kwargs.pop("zarr_version")
+    return kwargs
 
 
 def load_stac(
@@ -239,11 +253,7 @@ def load_stac(
         datasets = []
         for item in items:
             for asset in item.assets.values():
-                kwargs = (
-                    asset.extra_fields.get("xarray:open_kwargs", {})
-                    if use_xarray_open_kwargs
-                    else {"engine": "zarr", "consolidated": True, "chunks": {}}
-                )
+                kwargs = _zarr_open_kwargs(asset, use_xarray_open_kwargs)
 
                 if use_xarray_storage_options:
                     storage_opts = asset.extra_fields.get("xarray:storage_options", {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,31 +25,34 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
+dask = {extras = ["array", "dataframe", "distributed"], version = ">=2023.4.0", optional = true}
+dask-geopandas = { version = ">=0.4.3", optional = true }
 gdal = { version = ">=3.8.4", optional = true }
 geopandas = { version = ">=0.11.1", optional = true }
-pandas = { version = ">=2.2.0", optional = true }
-xarray = { version = ">=2022.11.0", optional = true }
-dask = {extras = ["array", "dataframe", "distributed"], version = ">=2023.4.0", optional = true}
-rasterio = { version = "^1.3.4", optional = true }
-dask-geopandas = { version = ">=0.4.3", optional = true }
-xgboost = { version = ">=1.5.1", extras = ["dask"], optional = true }
-rioxarray = { version = ">=0.12.0,<1", optional = true }
-openeo-pg-parser-networkx = { version = ">=2025.10", optional = true }
-rqadeforestation = { version = ">=0.1", optional = true }
-odc-geo = { version = ">=0.4.1,<1", optional = true }
-stac_validator = { version = ">=3.3.1", optional = true }
-odc-stac = { version = ">=0.3.9", optional = true }
-pystac_client = { version = ">=0.6.1", optional = true }
-planetary_computer = { version = ">=0.5.1", optional = true }
-scipy = "^1.11.3"
-xvec = { version = "0.2.0", optional = true }
-joblib = { version = ">=1.3.2", optional = true }
 geoparquet = "^0.0.3"
-pyarrow = ">=15.0.2"
-openeo = ">=0.36.0"
+joblib = { version = ">=1.3.2", optional = true }
 numpy = { version = ">=1.26.3,<3", optional = false }
+odc-geo = { version = ">=0.4.1,<1", optional = true }
+# odc-stac depends on odc-loader, but it's odc-loader that needs to be
+# compatible with the zarr package, so depend on odc-loader to get the right
+# version constraint for the zarr package.
+odc-loader = { version = ">=0.5", extras = ["zarr"], optional = true }
+odc-stac = { version = ">=0.3.9", optional = true }
+openeo = ">=0.36.0"
+openeo-pg-parser-networkx = { version = ">=2025.10", optional = true }
+pandas = { version = ">=2.2.0", optional = true }
+planetary_computer = { version = ">=0.5.1", optional = true }
+pyarrow = ">=15.0.2"
 pystac = { version = ">=1.12.0", optional = true }
-zarr = "<=2.18.7"
+pystac_client = { version = ">=0.6.1", optional = true }
+rasterio = { version = "^1.3.4", optional = true }
+rioxarray = { version = ">=0.12.0,<1", optional = true }
+rqadeforestation = { version = ">=0.1", optional = true }
+scipy = "^1.11.3"
+stac_validator = { version = ">=3.3.1", optional = true }
+xarray = { version = ">=2022.11.0", optional = true }
+xgboost = { version = ">=1.5.1", extras = ["dask"], optional = true }
+xvec = { version = "0.2.0", optional = true }
 
 
 [tool.poetry.group.ci.dependencies]
@@ -58,6 +61,8 @@ zarr = "<=2.18.7"
 #
 # This GDAL version and the version in .github/ci-environment.yml need to agree.
 gdal = { version = "<3.13.2" }
+# Zarr v3 compatibility for test_load_stac.py::test_load_stac.
+xarray = { version = ">=2025.06.0" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=9.0.3"
@@ -71,7 +76,7 @@ pytest-cov = ">=7.0.0"
 
 [tool.poetry.extras]
 civersions = ["gdal"]
-implementations = ["gdal", "geopandas", "xarray", "dask", "rasterio", "dask-geopandas", "rioxarray", "openeo-pg-parser-networkx", "odc-geo", "odc-stac", "planetary_computer", "pystac_client", "pystac", "stac_validator", "xvec", "joblib"]
+implementations = ["gdal", "geopandas", "xarray", "dask", "rasterio", "dask-geopandas", "rioxarray", "openeo-pg-parser-networkx", "odc-geo", "odc-loader", "odc-stac", "planetary_computer", "pystac_client", "pystac", "stac_validator", "xvec", "joblib"]
 ml = ["xgboost"]
 deforestation = ["rqadeforestation"]
 

--- a/tests/test_load_stac.py
+++ b/tests/test_load_stac.py
@@ -1,18 +1,71 @@
+import pathlib
 import shutil
+import tempfile
+from importlib.metadata import version as _pkg_version
 
 import numpy as np
+import pystac
 import pytest
 import xarray as xr
+from packaging.version import parse as parse_version
 
 from openeo_processes_dask.process_implementations.cubes.load import load_stac, load_url
+from openeo_processes_dask.process_implementations.exceptions import OpenEOException
 from tests.mockdata import create_fake_rastercube
+
+_STAC_TEMPLATE_PATH = pathlib.Path("tests/data/stac/s2_l2a_zarr_sample.json")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_zarr_v3_available: bool = parse_version(_pkg_version("zarr")) >= parse_version("3")
+
+
+def _make_zarr_stac_item(
+    zarr_path: pathlib.Path,
+    *,
+    open_kwargs: dict | None = None,
+    storage_options: dict | None = None,
+) -> pathlib.Path:
+    """Create a temporary STAC Item JSON pointing to *zarr_path*.
+
+    If *open_kwargs* is ``None`` the ``xarray:open_kwargs`` field is
+    removed from the asset.  Same for *storage_options*.
+    """
+    item = pystac.read_file(str(_STAC_TEMPLATE_PATH))
+    asset = item.assets["data"]
+    asset.href = str(zarr_path)
+
+    if open_kwargs is not None:
+        asset.extra_fields["xarray:open_kwargs"] = open_kwargs
+    else:
+        asset.extra_fields.pop("xarray:open_kwargs", None)
+
+    if storage_options is not None:
+        asset.extra_fields["xarray:storage_options"] = storage_options
+    else:
+        asset.extra_fields.pop("xarray:storage_options", None)
+
+    stac_path = zarr_path.parent / f"{zarr_path.name}_stac.json"
+    pystac.write_file(item, dest_href=str(stac_path), include_self_link=False)
+    return stac_path
+
+
+def _create_cube_for_zarr(bounding_box, random_raster_data, temporal_interval):
+    return create_fake_rastercube(
+        data=random_raster_data,
+        spatial_extent=bounding_box,
+        temporal_extent=temporal_interval,
+        bands=["B02", "B03", "B04", "B08", "SCL"],
+        backend="numpy",
+    )
 
 
 @pytest.mark.parametrize("size", [(10, 10, 10, 5)])
 @pytest.mark.parametrize("dtype", [np.float32])
-# @pytest.mark.parametrize("dims", [("x", "y", "t", "bands")])
-
-
 def test_load_stac(bounding_box, random_raster_data, temporal_interval):
     url = "./tests/data/stac/s2_l2a_test_item.json"
     output_cube = load_stac(
@@ -49,6 +102,69 @@ def test_load_stac(bounding_box, random_raster_data, temporal_interval):
     assert len(output_cube[output_cube.openeo.band_dims[0]]) > 0
     assert len(output_cube[output_cube.openeo.temporal_dims[0]]) > 0
     shutil.rmtree("./tests/data/s2_l2a_zarr_sample.zarr")
+
+
+# ---------------------------------------------------------------------------
+# Zarr format compatibility tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("size", [(10, 10, 10, 5)])
+@pytest.mark.parametrize("dtype", [np.float32])
+@pytest.mark.parametrize("zarr_version", [2, 3])
+def test_load_stac_zarr_with_open_kwargs(
+    bounding_box, random_raster_data, temporal_interval, tmp_path, zarr_version
+):
+    if zarr_version == 3 and not _zarr_v3_available:
+        pytest.skip("Zarr v3 is not supported in this configuration")
+
+    cube = _create_cube_for_zarr(bounding_box, random_raster_data, temporal_interval)
+    zarr_path = tmp_path / f"v{zarr_version}_with_kwargs.zarr"
+    cube.to_dataset(dim="bands").to_zarr(str(zarr_path), zarr_format=zarr_version)
+
+    open_kwargs = {"engine": "zarr", "chunks": {}, "zarr_format": zarr_version}
+    stac_path = _make_zarr_stac_item(zarr_path, open_kwargs=open_kwargs)
+    output_cube = load_stac(url=str(stac_path), bands=["B04"])
+
+    assert output_cube.openeo is not None
+    assert "B04" in output_cube[output_cube.openeo.band_dims[0]].values
+
+
+@pytest.mark.parametrize("size", [(10, 10, 10, 5)])
+@pytest.mark.parametrize("dtype", [np.float32])
+@pytest.mark.parametrize("consolidated", [True, False])
+def test_load_stac_zarr_v2_without_open_kwargs(
+    bounding_box, random_raster_data, temporal_interval, tmp_path, consolidated
+):
+    cube = _create_cube_for_zarr(bounding_box, random_raster_data, temporal_interval)
+    consolidated_label = "consolidated" if consolidated else "unconsolidated"
+    zarr_path = tmp_path / f"v2_{consolidated_label}.zarr"
+    cube.to_dataset(dim="bands").to_zarr(
+        str(zarr_path), zarr_format=2, consolidated=consolidated
+    )
+
+    stac_path = _make_zarr_stac_item(zarr_path, open_kwargs=None)
+    output_cube = load_stac(url=str(stac_path), bands=["B04"])
+
+    assert output_cube.openeo is not None
+    assert "B04" in output_cube[output_cube.openeo.band_dims[0]].values
+
+
+def test_load_stac_zarr_missing_requested_band(bounding_box, tmp_path):
+    zarr_path = tmp_path / "missing_band.zarr"
+    ds = xr.Dataset(
+        {"B04": (("t", "y", "x"), np.ones((1, 10, 10), dtype=np.float32))},
+        coords={
+            "t": [np.datetime64("2022-06-02")],
+            "y": np.arange(10),
+            "x": np.arange(10),
+        },
+    )
+    ds.to_zarr(str(zarr_path), zarr_format=2)
+
+    stac_path = _make_zarr_stac_item(zarr_path, open_kwargs=None)
+    with pytest.raises(OpenEOException, match="missing_band"):
+        load_stac(url=str(stac_path), bands=["missing_band"])
 
 
 def test_load_url():


### PR DESCRIPTION
## Description

This PR adds runtime Zarr v3 support to `openeo-processes-dask`, addressing `#376` and building on the dependency-only fix from PR `#385`.

PR `#385` removed the hard `zarr = "<=2.18.7"` constraint and added `odc-loader[zarr]`, which resolved the install conflict. However, Zarr v3 stores could still fail at runtime because `load_stac()` hardcoded Zarr open options.

## Changes

* Adds `_zarr_open_kwargs()` in `load.py`

  * Respects STAC `xarray:open_kwargs`
  * Maps `zarr_version` to `zarr_format`
  * Avoids forcing `consolidated=True`, which is unsupported by `zarr-python 3`
  * Keeps sensible defaults: `engine="zarr"` and `chunks={}`

* Updates dependency handling in `pyproject.toml`

  * Replaces the direct Zarr ceiling with `odc-loader[zarr]`
  * Adds `xarray >=2025.06.0` to the CI group for Zarr v3 `_FillValue` compatibility
  * Adds `odc-loader` to implementation extras

* Adds 6 tests covering Zarr v2/v3 loading scenarios, open kwargs handling, missing band errors, and temporary STAC item helpers.

## Testing

```text
319 tests passed, 1 skipped
```

The skipped test is the Zarr v3 test when `zarr-python 3` is not installed.
