### PR TITLE
inspect: fix type annotations

### DIFF
--- a/openeo_processes_dask/process_implementations/inspect.py
+++ b/openeo_processes_dask/process_implementations/inspect.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Any, Literal
 
 __all__ = ["inspect"]
 
@@ -8,9 +8,11 @@ logger = logging.getLogger(__name__)
 
 def inspect(
     data: Any,
-    message: Optional[str] = "",
-    code: Optional[str] = "User",
-    level: Optional[str] = "info",
+    message: str = "",
+    code: str = "User",
+    level: Literal[
+        "INFO", "WARNING", "ERROR", "DEBUG", "info", "warning", "error", "debug"
+    ] = "info",
 ) -> Any:
     if level.lower() == "info":
         logger.info(f"{code}: {message} {data}.")


### PR DESCRIPTION
None of these parameters are
optional, passing in None
for level will crash, and
the results of passing in
None for the other parameters
don't really make sense.