### PR TITLE
CI: test with GDAL 3.13.1

### DIFF
--- a/.github/ci-environment.yml
+++ b/.github/ci-environment.yml
@@ -2,4 +2,4 @@ name: ci
 channels:
   - conda-forge
 dependencies:
-  - gdal=3.13.0
+  - gdal=3.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,9 @@ zarr = "<=2.18.7"
 [tool.poetry.group.ci.dependencies]
 # CI-only version ceilings: protect CI from upstream breakage without
 # imposing ceilings on downstream consumers. See README for policy.
-gdal = { version = "<3.13.1" }
+#
+# This GDAL version and the version in .github/ci-environment.yml need to agree.
+gdal = { version = "<3.13.2" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=9.0.3"


### PR DESCRIPTION
There are now Conda packages
of GDAL 3.13.1, so bump
the version to use those.