### PR TITLE
pyproject: use PEP-621 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project requires **GDAL >=3.8.4** (the version shipped by Ubuntu 24.04) and
 
 ## Development environment
 
-openeo-processes-dask requires poetry >1.2, see their [docs](https://python-poetry.org/docs/#installation) for installation instructions.
+This package requires at least Poetry 2.2, see their [docs](https://python-poetry.org/docs/#installation) for installation instructions.
 
 Clone the repository with `--recurse-submodules` to also fetch the process specs:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,16 @@
-[tool.poetry]
+[project]
 name = "openeo-processes-dask"
 version = "2026.6.3"
 description = "Python implementations of many OpenEO processes, dask-friendly by default."
-authors = ["Lukas Weidenholzer <lukas.weidenholzer@eodc.eu>", "Sean Hoyal <sean.hoyal@eodc.eu>", "Valentina Hutter <valentina.hutter@eodc.eu>"]
-maintainers = ["EODC Staff <support@eodc.eu>"]
-license = "Apache 2.0"
+authors = [
+    {name = "Lukas Weidenholzer", email = "lukas.weidenholzer@eodc.eu"},
+    {name = "Sean Hoyal", email = "sean.hoyal@eodc.eu"},
+    {name = "Valentina Hutter", email = "valentina.hutter@eodc.eu"},
+]
+maintainers = [
+    {name = "EODC Staff", email = "support@eodc.eu"},
+]
+license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Open-EO/openeo-processes-dask"
 classifiers = [
@@ -18,67 +24,64 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-
-packages = [
-    { include = "openeo_processes_dask" }
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "geoparquet ==0.0.3",
+    "numpy >=1.26.3,<3",
+    "openeo >=0.36.0",
+    "pyarrow >=15.0.2",
+    "scipy >=1.11.3, <2",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.10,<3.14"
-dask = {extras = ["array", "dataframe", "distributed"], version = ">=2023.4.0", optional = true}
-dask-geopandas = { version = ">=0.4.3", optional = true }
-gdal = { version = ">=3.8.4", optional = true }
-geopandas = { version = ">=0.11.1", optional = true }
-geoparquet = "^0.0.3"
-joblib = { version = ">=1.3.2", optional = true }
-numpy = { version = ">=1.26.3,<3", optional = false }
-odc-geo = { version = ">=0.4.1,<1", optional = true }
-# odc-stac depends on odc-loader, but it's odc-loader that needs to be
-# compatible with the zarr package, so depend on odc-loader to get the right
-# version constraint for the zarr package.
-odc-loader = { version = ">=0.5", extras = ["zarr"], optional = true }
-odc-stac = { version = ">=0.3.9", optional = true }
-openeo = ">=0.36.0"
-openeo-pg-parser-networkx = { version = ">=2025.10", optional = true }
-pandas = { version = ">=2.2.0", optional = true }
-planetary_computer = { version = ">=0.5.1", optional = true }
-pyarrow = ">=15.0.2"
-pystac = { version = ">=1.12.0", optional = true }
-pystac_client = { version = ">=0.6.1", optional = true }
-rasterio = { version = "^1.3.4", optional = true }
-rioxarray = { version = ">=0.12.0,<1", optional = true }
-rqadeforestation = { version = ">=0.1", optional = true }
-scipy = "^1.11.3"
-stac_validator = { version = ">=3.3.1", optional = true }
-xarray = { version = ">=2022.11.0", optional = true }
-xgboost = { version = ">=1.5.1", extras = ["dask"], optional = true }
-xvec = { version = "0.2.0", optional = true }
+[project.optional-dependencies]
+deforestation = ["rqadeforestation >=0.1"]
+implementations = [
+    "dask[array, dataframe, distributed] >=2023.4.0",
+    "dask-geopandas >=0.4.3",
+    "gdal >=3.8.4",
+    "geopandas >=0.11.1",
+    "joblib >=1.3.2",
+    "odc-geo >=0.4.1,<1",
+    # odc-stac depends on odc-loader, but it's odc-loader that needs to be
+    # compatible with the zarr package, so depend on odc-loader to get the right
+    # version constraint for the zarr package.
+    "odc-loader[zarr] >=0.5",
+    "odc-stac >=0.3.9",
+    "openeo-pg-parser-networkx >=2025.10",
+    "planetary_computer >=0.5.1",
+    "pystac >=1.12.0",
+    "pystac_client>=0.6.1",
+    "rasterio >=1.3.4",
+    "rioxarray >=0.12.0,<1",
+    "stac_validator >=3.3.1",
+    "xarray >=2022.11.0",
+    "xvec ==0.2.0",
+]
+ml = ["xgboost[dask] >=1.5.1"]
 
 
-[tool.poetry.group.ci.dependencies]
+[dependency-groups]
 # CI-only version ceilings: protect CI from upstream breakage without
 # imposing ceilings on downstream consumers. See README for policy.
-#
-# This GDAL version and the version in .github/ci-environment.yml need to agree.
-gdal = { version = "<3.13.2" }
-# Zarr v3 compatibility for test_load_stac.py::test_load_stac.
-xarray = { version = ">=2025.06.0" }
+ci = [
+    # This GDAL version and the version in .github/ci-environment.yml need
+    # to agree.
+    "gdal<3.13.2",
+    # Zarr v3 compatibility for test_load_stac.py::test_load_stac.
+    "xarray >=2025.06.0",
+]
+dev = [
+    "folium >=0.12.1,<1",
+    "ipykernel >=6.15.1, <7",
+    "mapclassify >=2.4.3, <3",
+    "matplotlib >=3.5.3, <4",
+    "pre-commit >=2.20.0, <3",
+    "pytest >=9.0.3",
+    "pytest-cov >=7.0.0",
+]
 
-[tool.poetry.group.dev.dependencies]
-pytest = ">=9.0.3"
-ipykernel = "^6.15.1"
-matplotlib = "^3.5.3"
-folium = ">=0.12.1,<1"
-mapclassify = "^2.4.3"
-pre-commit = "^2.20.0"
-pytest-cov = ">=7.0.0"
-
-
-[tool.poetry.extras]
-civersions = ["gdal"]
-implementations = ["gdal", "geopandas", "xarray", "dask", "rasterio", "dask-geopandas", "rioxarray", "openeo-pg-parser-networkx", "odc-geo", "odc-loader", "odc-stac", "planetary_computer", "pystac_client", "pystac", "stac_validator", "xvec", "joblib"]
-ml = ["xgboost"]
-deforestation = ["rqadeforestation"]
+[tool.poetry]
+requires-poetry = ">=2.2"
 
 [tool.pytest.ini_options]
 console_output_style = "times"
@@ -87,5 +90,5 @@ testpaths = [
 ]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Require Poetry 2.2 from September 2025
and convert pyproject.toml to
a format that other tools also
support.

Push the version constraints for
the optionals into the respective
optional-dependency group since
each extra is only required once.