### PR TITLE
load: always define variable

### DIFF
--- a/openeo_processes_dask/process_implementations/cubes/load.py
+++ b/openeo_processes_dask/process_implementations/cubes/load.py
@@ -68,6 +68,7 @@ def _search_for_parent_catalog(url):
     catalog_url = root_url
     url_parts = PurePosixPath(unquote(parsed_url.path)).parts
     collection_id = url_parts[-1]
+    asset_type = None
     for p in url_parts:
         if p != "/":
             catalog_url = catalog_url + "/" + p


### PR DESCRIPTION
Accessing unbound variables
tends to be bad, so make sure
the variable is defined.