### PR TITLE
Remove unused imports

### DIFF
--- a/openeo_processes_dask/process_implementations/arrays.py
+++ b/openeo_processes_dask/process_implementations/arrays.py
@@ -1,5 +1,3 @@
-import copy
-import itertools
 import logging
 from typing import Any, Callable, Optional, Union
 
@@ -9,7 +7,6 @@ import pandas as pd
 import xarray as xr
 from numpy.typing import ArrayLike
 from openeo_pg_parser_networkx.pg_schema import DateTime
-from xarray.core.duck_array_ops import isnull, notnull
 
 from openeo_processes_dask.process_implementations.comparison import is_valid
 from openeo_processes_dask.process_implementations.cubes.utils import _is_dask_array

--- a/openeo_processes_dask/process_implementations/comparison.py
+++ b/openeo_processes_dask/process_implementations/comparison.py
@@ -1,13 +1,9 @@
 from typing import Optional
 
-import dask.array as da
 import numpy as np
 from numpy.typing import ArrayLike
 
-from openeo_processes_dask.process_implementations.cubes.utils import (
-    _is_dask_array,
-    notnull,
-)
+from openeo_processes_dask.process_implementations.cubes.utils import notnull
 from openeo_processes_dask.process_implementations.utils import get_scalar_type
 
 __all__ = [

--- a/openeo_processes_dask/process_implementations/cubes/_filter.py
+++ b/openeo_processes_dask/process_implementations/cubes/_filter.py
@@ -1,14 +1,10 @@
-import json
 import logging
 import warnings
 from typing import Any, Callable, Optional, Union
 
-import dask.array as da
 import geopandas as gpd
 import numpy as np
 import pyproj
-import rasterio
-import rioxarray
 import shapely
 import xarray as xr
 from openeo_pg_parser_networkx.pg_schema import BoundingBox, TemporalInterval

--- a/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
+++ b/openeo_processes_dask/process_implementations/cubes/_xr_interop.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-import odc.geo.xr  # Required for the .geo accessor on xarrays.
+# Required for the .geo accessor on xarrays.
+import odc.geo.xr  # noqa: F401
 import xarray as xr
 
 TEMPORAL_GUESSES = [

--- a/openeo_processes_dask/process_implementations/cubes/aggregate.py
+++ b/openeo_processes_dask/process_implementations/cubes/aggregate.py
@@ -1,17 +1,15 @@
 import copy
-import gc
 import logging
 from typing import Callable, Optional, Union
 
-import dask.array as da
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import rasterio
 import shapely
 import xarray as xr
-import xvec
-from joblib import Parallel, delayed
+
+# Required to get .xvec attribute on DataArray.
+import xvec  # noqa: F401
 from openeo_pg_parser_networkx.pg_schema import TemporalInterval, TemporalIntervals
 
 from openeo_processes_dask.process_implementations.data_model import (

--- a/openeo_processes_dask/process_implementations/cubes/apply.py
+++ b/openeo_processes_dask/process_implementations/cubes/apply.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional, Union
 import numpy as np
 import scipy.ndimage
 import xarray as xr
-from shapely.geometry import MultiPolygon, Polygon, shape
+from shapely.geometry import MultiPolygon, shape
 from shapely.ops import unary_union
 
 from openeo_processes_dask.process_implementations.cubes.mask_polygon import (

--- a/openeo_processes_dask/process_implementations/cubes/apply_neighborhood_intertwin.py
+++ b/openeo_processes_dask/process_implementations/cubes/apply_neighborhood_intertwin.py
@@ -1,8 +1,4 @@
-from typing import Any, Callable, Optional
-
-import numpy as np
-import numpy.typing as npt
-import xarray as xr
+from typing import Callable, Optional
 
 from openeo_processes_dask.process_implementations.data_model import RasterCube
 

--- a/openeo_processes_dask/process_implementations/cubes/geometries.py
+++ b/openeo_processes_dask/process_implementations/cubes/geometries.py
@@ -6,7 +6,9 @@ import geopandas as gpd
 import numpy as np
 import shapely
 import xarray as xr
-import xvec
+
+# Required to get .xvec attribute on DataArray.
+import xvec  # noqa: F401
 
 from openeo_processes_dask.process_implementations.data_model import VectorCube
 from openeo_processes_dask.process_implementations.exceptions import (

--- a/openeo_processes_dask/process_implementations/cubes/load.py
+++ b/openeo_processes_dask/process_implementations/cubes/load.py
@@ -1,17 +1,13 @@
-import datetime
 import json
 import logging
 import tempfile
-from collections.abc import Iterator
-from datetime import datetime
 from pathlib import PurePosixPath
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Union
 from urllib.parse import unquote, urlparse
 
 import numpy as np
 import odc.stac
 import planetary_computer as pc
-import pyproj
 import pystac
 import pystac_client
 import xarray as xr
@@ -21,16 +17,11 @@ from stac_validator import stac_validator
 
 from openeo_processes_dask.process_implementations.cubes._filter import (
     _reproject_bbox,
-    filter_bands,
     filter_bbox,
     filter_temporal,
 )
 from openeo_processes_dask.process_implementations.data_model import RasterCube
-from openeo_processes_dask.process_implementations.exceptions import (
-    NoDataAvailable,
-    OpenEOException,
-    TemporalExtentEmpty,
-)
+from openeo_processes_dask.process_implementations.exceptions import OpenEOException
 
 # "NoDataAvailable": {
 #     "message": "There is no data available for the given extents."
@@ -384,7 +375,8 @@ def load_url(url: str, format: Literal["GeoJSON", "JSON", "Parquet"], options={}
     elif format == "JSON":
         return url_json
 
-    import xvec
+    # Required to get .xvec attribute on DataArray.
+    import xvec  # noqa: F401
 
     if not hasattr(gdf, "crs"):
         gdf = gdf.set_crs("epsg:4326")

--- a/openeo_processes_dask/process_implementations/cubes/mask.py
+++ b/openeo_processes_dask/process_implementations/cubes/mask.py
@@ -1,12 +1,10 @@
 import logging
-from typing import Callable
 
 import numpy as np
 
 from openeo_processes_dask.process_implementations.cubes.resample import (
     resample_cube_spatial,
 )
-from openeo_processes_dask.process_implementations.cubes.utils import notnull
 from openeo_processes_dask.process_implementations.data_model import RasterCube
 from openeo_processes_dask.process_implementations.exceptions import (
     DimensionLabelCountMismatch,

--- a/openeo_processes_dask/process_implementations/cubes/mask_polygon.py
+++ b/openeo_processes_dask/process_implementations/cubes/mask_polygon.py
@@ -6,9 +6,7 @@ import dask.array as da
 import geopandas as gpd
 import numpy as np
 import rasterio
-import rioxarray
 import shapely
-import xarray as xr
 from xarray.core import dtypes
 
 from openeo_processes_dask.process_implementations.data_model import (

--- a/openeo_processes_dask/process_implementations/cubes/resample.py
+++ b/openeo_processes_dask/process_implementations/cubes/resample.py
@@ -2,8 +2,9 @@ import logging
 from typing import Optional, Union
 
 import numpy as np
-import odc.geo.xr
-import rioxarray  # needs to be imported to set .rio accessor on xarray objects.
+
+# Needs to be imported to set .rio accessor on xarray objects.
+import rioxarray  # noqa: F401
 import xarray as xr
 from odc.geo.geobox import resolution_from_affine
 from pyproj.crs import CRS, CRSError

--- a/openeo_processes_dask/process_implementations/experimental/ddmc.py
+++ b/openeo_processes_dask/process_implementations/experimental/ddmc.py
@@ -1,7 +1,5 @@
-from openeo_processes_dask.process_implementations.arrays import array_element
 from openeo_processes_dask.process_implementations.cubes.general import add_dimension
 from openeo_processes_dask.process_implementations.cubes.merge import merge_cubes
-from openeo_processes_dask.process_implementations.cubes.reduce import reduce_dimension
 from openeo_processes_dask.process_implementations.data_model import RasterCube
 
 __all__ = ["ddmc"]

--- a/openeo_processes_dask/process_implementations/ml/curve_fitting.py
+++ b/openeo_processes_dask/process_implementations/ml/curve_fitting.py
@@ -1,11 +1,9 @@
-from typing import Callable, Optional
+from typing import Callable
 
 import numpy as np
-import pandas as pd
 import xarray as xr
 from numpy.typing import ArrayLike
 
-from openeo_processes_dask.process_implementations.cubes import apply_dimension
 from openeo_processes_dask.process_implementations.data_model import RasterCube
 from openeo_processes_dask.process_implementations.exceptions import (
     DimensionNotAvailable,

--- a/openeo_processes_dask/process_implementations/ml/random_forest.py
+++ b/openeo_processes_dask/process_implementations/ml/random_forest.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import dask
 import dask.distributed

--- a/openeo_processes_dask/process_implementations/utils.py
+++ b/openeo_processes_dask/process_implementations/utils.py
@@ -1,6 +1,4 @@
-import dask.array as da
 import numpy as np
-import xarray as xr
 
 
 def get_scalar_type(obj):

--- a/tests/general_checks.py
+++ b/tests/general_checks.py
@@ -1,5 +1,5 @@
 # Checks here are inspired by makepath/xarray-spatial/tests/general_checks.py
-from typing import List, Optional
+from typing import Optional
 
 import dask.array as da
 import numpy as np

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -4,7 +4,6 @@ import geopandas as gpd
 import numpy as np
 import pytest
 import xarray as xr
-import xvec
 from openeo_pg_parser_networkx.pg_schema import (
     ParameterReference,
     TemporalInterval,
@@ -13,7 +12,9 @@ from openeo_pg_parser_networkx.pg_schema import (
 
 from openeo_processes_dask.process_implementations.cubes.aggregate import *
 from openeo_processes_dask.process_implementations.cubes.reduce import reduce_dimension
-from openeo_processes_dask.process_implementations.math import mean
+
+# Required by test_aggregate_spatial().
+from openeo_processes_dask.process_implementations.math import mean  # noqa: F401
 from tests.general_checks import assert_numpy_equals_dask_numpy, general_output_checks
 from tests.mockdata import create_fake_rastercube
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -15,7 +15,7 @@ from openeo_processes_dask.process_implementations.cubes.apply import (
 from openeo_processes_dask.process_implementations.cubes.mask_polygon import (
     mask_polygon,
 )
-from tests.general_checks import assert_numpy_equals_dask_numpy, general_output_checks
+from tests.general_checks import general_output_checks
 from tests.mockdata import create_fake_rastercube
 
 

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -12,9 +12,7 @@ from openeo_processes_dask.process_implementations.arrays import *
 from openeo_processes_dask.process_implementations.cubes.reduce import reduce_dimension
 from openeo_processes_dask.process_implementations.exceptions import (
     ArrayElementNotAvailable,
-    TooManyDimensions,
 )
-from openeo_processes_dask.process_implementations.math import add
 from tests.general_checks import general_output_checks
 from tests.mockdata import create_fake_rastercube
 

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from functools import partial
 
 import dask
@@ -11,9 +10,8 @@ from openeo_pg_parser_networkx.pg_schema import ParameterReference
 from openeo_processes_dask.process_implementations import merge_cubes
 from openeo_processes_dask.process_implementations.comparison import *
 from openeo_processes_dask.process_implementations.cubes.apply import apply
-from openeo_processes_dask.process_implementations.cubes.reduce import reduce_dimension
 from openeo_processes_dask.process_implementations.utils import get_scalar_type
-from tests.general_checks import assert_numpy_equals_dask_numpy, general_output_checks
+from tests.general_checks import general_output_checks
 from tests.mockdata import create_fake_rastercube
 
 

--- a/tests/test_ddmc.py
+++ b/tests/test_ddmc.py
@@ -1,24 +1,9 @@
-from functools import partial
-
 import numpy as np
 import pytest
 import xarray as xr
-from openeo_pg_parser_networkx.pg_schema import (
-    BoundingBox,
-    ParameterReference,
-    TemporalInterval,
-)
+from openeo_pg_parser_networkx.pg_schema import BoundingBox, TemporalInterval
 
-from openeo_processes_dask.process_implementations.cubes.load import load_stac
-from openeo_processes_dask.process_implementations.cubes.reduce import (
-    reduce_dimension,
-    reduce_spatial,
-)
-from openeo_processes_dask.process_implementations.exceptions import (
-    ArrayElementNotAvailable,
-)
 from openeo_processes_dask.process_implementations.experimental.ddmc import ddmc
-from tests.general_checks import general_output_checks
 from tests.mockdata import create_fake_rastercube
 
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,4 @@
 import copy
-import datetime
 from functools import partial
 
 import numpy as np

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 import pytest
 import shapely
 import xarray as xr
-import xvec
 
 from openeo_processes_dask.process_implementations.cubes.geometries import *
 from openeo_processes_dask.process_implementations.exceptions import UnitMismatch

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from openeo_processes_dask.process_implementations.cubes.indices import ndvi
-from openeo_processes_dask.process_implementations.cubes.load import load_stac
 from openeo_processes_dask.process_implementations.exceptions import (
     BandExists,
     DimensionAmbiguous,

--- a/tests/test_load_stac.py
+++ b/tests/test_load_stac.py
@@ -1,6 +1,5 @@
 import pathlib
 import shutil
-import tempfile
 from importlib.metadata import version as _pkg_version
 
 import numpy as np

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -2,16 +2,13 @@ from functools import partial
 
 import numpy as np
 import pytest
-from openeo_pg_parser_networkx.pg_schema import ParameterReference, TemporalInterval
+from openeo_pg_parser_networkx.pg_schema import ParameterReference
 
 from openeo_processes_dask.process_implementations.cubes.mask import mask
 from openeo_processes_dask.process_implementations.cubes.mask_polygon import (
     mask_polygon,
 )
-from openeo_processes_dask.process_implementations.cubes.reduce import (
-    reduce_dimension,
-    reduce_spatial,
-)
+from openeo_processes_dask.process_implementations.cubes.reduce import reduce_dimension
 from tests.mockdata import create_fake_rastercube
 
 

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -5,12 +5,10 @@ import dask
 import geopandas as gpd
 import numpy as np
 import pytest
-import xarray as xr
 import xgboost as xgb
-from openeo_pg_parser_networkx.pg_schema import DEFAULT_CRS, ParameterReference
+from openeo_pg_parser_networkx.pg_schema import ParameterReference
 
 from openeo_processes_dask.process_implementations.core import process
-from openeo_processes_dask.process_implementations.cubes.apply import apply_dimension
 from openeo_processes_dask.process_implementations.cubes.general import dimension_labels
 from openeo_processes_dask.process_implementations.ml import (
     fit_curve,

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -18,13 +18,6 @@ from tests.mockdata import create_fake_rastercube
 def test_reduce_rqa(
     temporal_interval, bounding_box, random_raster_data, process_registry
 ):
-    import os
-
-    from openeo_processes_dask.process_implementations.arrays import array_apply
-    from openeo_processes_dask.process_implementations.cubes.apply import (
-        apply_dimension,
-    )
-
     try:
         from openeo_processes_dask.process_implementations.experimental import (
             rqadeforestation,

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -2,7 +2,6 @@ from functools import partial
 
 import numpy as np
 import pytest
-import xarray as xr
 from odc.geo.geobox import resolution_from_affine
 from openeo_pg_parser_networkx.pg_schema import ParameterReference, TemporalInterval
 from pyproj.crs import CRS

--- a/tests/test_udf.py
+++ b/tests/test_udf.py
@@ -1,5 +1,4 @@
 import numpy as np
-import openeo
 import pytest
 import xarray as xr
 

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from openeo_processes_dask.process_implementations import drop_dimension
 from tests.mockdata import create_fake_rastercube
 
 


### PR DESCRIPTION
Remove the imports that are unused
except for the ones that are
required for accessors on arrays,
and annotate those with a
"noqa: F401" so linters won't flag
these imports as unused in
the future.