### PR TITLE
CI: run with fewer permissions

### DIFF
--- a/.github/workflows/install-methods.yml
+++ b/.github/workflows/install-methods.yml
@@ -9,6 +9,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ on:
 env:
   POETRY_VERSION: 2.3.3
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 env:
   POETRY_VERSION: 2.3.3
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:


### PR DESCRIPTION
Set the top level permissions
to the empty set so CI jobs
don't run with excessive
permissions.