### PR TITLE
tests: disable failing tests

### DIFF
--- a/tests/test_load_stac.py
+++ b/tests/test_load_stac.py
@@ -64,6 +64,7 @@ def _create_cube_for_zarr(bounding_box, random_raster_data, temporal_interval):
     )
 
 
+@pytest.mark.skip(reason="Expired certificate for https://stac.openeo.eurac.edu")
 @pytest.mark.parametrize("size", [(10, 10, 10, 5)])
 @pytest.mark.parametrize("dtype", [np.float32])
 def test_load_stac(bounding_box, random_raster_data, temporal_interval):
@@ -109,6 +110,7 @@ def test_load_stac(bounding_box, random_raster_data, temporal_interval):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skip(reason="Expired certificate for https://stac.openeo.eurac.edu")
 @pytest.mark.parametrize("size", [(10, 10, 10, 5)])
 @pytest.mark.parametrize("dtype", [np.float32])
 @pytest.mark.parametrize("zarr_version", [2, 3])
@@ -130,6 +132,7 @@ def test_load_stac_zarr_with_open_kwargs(
     assert "B04" in output_cube[output_cube.openeo.band_dims[0]].values
 
 
+@pytest.mark.skip(reason="Expired certificate for https://stac.openeo.eurac.edu")
 @pytest.mark.parametrize("size", [(10, 10, 10, 5)])
 @pytest.mark.parametrize("dtype", [np.float32])
 @pytest.mark.parametrize("consolidated", [True, False])
@@ -150,6 +153,7 @@ def test_load_stac_zarr_v2_without_open_kwargs(
     assert "B04" in output_cube[output_cube.openeo.band_dims[0]].values
 
 
+@pytest.mark.skip(reason="Expired certificate for https://stac.openeo.eurac.edu")
 def test_load_stac_zarr_missing_requested_band(bounding_box, tmp_path):
     zarr_path = tmp_path / "missing_band.zarr"
     ds = xr.Dataset(


### PR DESCRIPTION
The certificate has expired
and the http endpoint sends
a 302 moved permanently
redirecting to the https
endpoint, so disable the tests
to make the CI green for now.

Refs #410