### PR TITLE
math: name the deprecated parameter

### DIFF
--- a/openeo_processes_dask/process_implementations/math.py
+++ b/openeo_processes_dask/process_implementations/math.py
@@ -365,7 +365,7 @@ def quantiles(
 
     if q is not None:
         logger.warning(
-            "This parameter has been **deprecated**. Please use the parameter `probabilities` instead."
+            "The 'q' parameter has been **deprecated**. Please use the parameter `probabilities` instead."
         )
         probabilities = np.arange(1.0 / q, 1, 1.0 / q)
 


### PR DESCRIPTION
The user doesn't know what "this"
refers to, so state the name
of the parameter in the log
message.