### PR TITLE
core: fix type signatures

### DIFF
--- a/openeo_processes_dask/process_implementations/core.py
+++ b/openeo_processes_dask/process_implementations/core.py
@@ -2,7 +2,7 @@ import importlib
 import inspect
 import logging
 from functools import wraps
-from typing import Optional
+from typing import Any
 
 from openeo_pg_parser_networkx.pg_schema import ParameterReference
 
@@ -24,8 +24,8 @@ def process(f):
     @wraps(f)
     def wrapper(
         *args,
-        positional_parameters: Optional[dict[int]] = None,
-        named_parameters: Optional[dict[str]] = None,
+        positional_parameters: dict[int, Any] | None = None,
+        named_parameters: dict[str, Any] | None = None,
         **kwargs,
     ):
         # Need to transform this from a tuple to a list to be able to delete from it.


### PR DESCRIPTION
This fixes most of the complaints
from the type checker for this file.

Also update to use Python 3.10 type
signatures since I'm already changing
these lines and ending up in git blame.