### PR TITLE
core: convert int to string

### DIFF
--- a/openeo_processes_dask/process_implementations/core.py
+++ b/openeo_processes_dask/process_implementations/core.py
@@ -46,7 +46,7 @@ def process(f):
 
         # If an arg is specified in positional_parameters, put the correct key-value pair into named_parameters
         for arg_name, i in positional_parameters.items():
-            named_parameters[arg_name] = args[i]
+            named_parameters[str(arg_name)] = args[i]
 
         for arg in args:
             if isinstance(arg, ParameterReference):


### PR DESCRIPTION
Assuming that dict[int] means
a dictionary with integer keys,
there's a missing string
conversion for it to be compatible
with the dictionary it is
being merged into.

If my guess of what dict[int] means
is wrong, then the str() should
be in the RHS of this line instead.