### PR TITLE
Add sorting of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: What's Changed
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: Automated Updates
+      labels:
+        - dependencies


### PR DESCRIPTION
Put in the example from
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations but with the headings used
for our releases.